### PR TITLE
[Provision] Add SDP booting and block-device detection to tool

### DIFF
--- a/cmd/provision/main.go
+++ b/cmd/provision/main.go
@@ -125,6 +125,10 @@ func waitAndProvision(fw *firmware) error {
 		klog.Info("Witness device booting recovering image ✅")
 		return nil
 	})
+	if err != nil {
+		return fmt.Errorf("failed to detect block device: %v", err)
+
+	}
 	klog.Infof("Detected blockdevice %v ✅", bDev)
 
 	// TODO: which block device?

--- a/cmd/provision/sdp.go
+++ b/cmd/provision/sdp.go
@@ -177,10 +177,14 @@ func (t *Target) fileWrite(imx []byte, addr uint32) error {
 		return fmt.Errorf("failed to send FileWriteReport r1: %v", err)
 	}
 
+	// Don't wait for report responses until we've sent the final block.
 	wait := -1
 
 	for i, r := range r2 {
 		if i == len(r2)-1 {
+			// We're now sending the final chunk of the imx, so wait for
+			// report ID 4 - this report indicates completion of the
+			// FileWrite request.
 			wait = 4
 		}
 	send:

--- a/cmd/provision/sdp.go
+++ b/cmd/provision/sdp.go
@@ -127,7 +127,7 @@ func (t *Target) BootIMX(imx []byte) error {
 		return fmt.Errorf("failed to set jump address: %v", err)
 	}
 
-	klog.Infof("✅ Serial download on %s complete", t.DeviceInfo.Path)
+	klog.Infof("Serial download on %s complete", t.DeviceInfo.Path)
 	return nil
 }
 

--- a/cmd/provision/sdp.go
+++ b/cmd/provision/sdp.go
@@ -1,0 +1,225 @@
+// Copyright 2023 The Armored Witness authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Large portions of this file come from github.com/armory-boot/cmd/armory-boot-usb.
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"runtime"
+	"sync"
+	"time"
+
+	"github.com/usbarmory/armory-boot/sdp"
+	"k8s.io/klog"
+
+	"github.com/usbarmory/hid"
+)
+
+const (
+	// USB vendor ID for all supported devices
+	FreescaleVendorID = 0x15a2
+
+	// On-Chip RAM (OCRAM/iRAM) address for payload staging
+	iramOffset = 0x00910000
+)
+
+var (
+	// These are the only supported devices for the armored witness.
+	supportedDevices = map[uint16]string{
+		0x007d: "Freescale SemiConductor Inc  SE Blank 6UL",
+		0x0080: "Freescale SemiConductor Inc  SE Blank 6ULL",
+	}
+
+	Timeout = 10 * time.Second
+)
+
+// Target represents a valid device to be SDP booted
+type Target struct {
+	sync.Mutex
+
+	// DeviceInfo allows callers to inspect details of the device (e.g. to differentiate
+	// between multiple units connected at once).
+	DeviceInfo hid.DeviceInfo
+
+	// dev is the opened device, or nil
+	dev hid.Device
+}
+
+// DetectHID returns a list of compatible devices in SDP mode.
+func DetectHID() ([]*Target, error) {
+	devices, err := hid.Devices()
+	if err != nil {
+		return nil, err
+	}
+
+	var ret []*Target
+	for _, d := range devices {
+		d := d
+		if d.VendorID != FreescaleVendorID {
+			continue
+		}
+
+		if product, ok := supportedDevices[d.ProductID]; ok {
+			klog.Infof("found device %04x:%04x %s", d.VendorID, d.ProductID, product)
+		} else {
+			continue
+		}
+
+		ret = append(ret, &Target{DeviceInfo: *d})
+	}
+
+	return ret, nil
+}
+
+// BootIMX attempts to use SDP to send an IMX image to the target, and boot it.
+func (t *Target) BootIMX(imx []byte) error {
+	t.Lock()
+	var err error
+	if t.dev, err = t.DeviceInfo.Open(); err != nil {
+		return fmt.Errorf("failed to open device %q: %v", t.DeviceInfo.Path, err)
+	}
+	defer func() {
+		if t.dev != nil {
+			t.dev.Close()
+		}
+		t.dev = nil
+		t.Unlock()
+	}()
+
+	klog.Infof("Attempting to SDP boot device %s", t.DeviceInfo.Path)
+
+	ivt, err := sdp.ParseIVT(imx)
+	if err != nil {
+		return fmt.Errorf("failed to parse IVT: %v", err)
+	}
+
+	dcd, err := sdp.ParseDCD(imx, ivt)
+	if err != nil {
+		return fmt.Errorf("failed to parse DCD: %v", err)
+	}
+
+	klog.Infof("Loading DCD at %#08x (%d bytes)", iramOffset, len(dcd))
+	if err = t.dcdWrite(dcd, iramOffset); err != nil {
+		return fmt.Errorf("failed to write DCD: %v", err)
+	}
+
+	klog.Infof("Loading imx to %#08x (%d bytes)", ivt.Self, len(imx))
+	if err = t.fileWrite(imx, ivt.Self); err != nil {
+		return fmt.Errorf("failed to write IMX file: %v", err)
+	}
+
+	klog.Infof("Sending jump address to %#08x", ivt.Self)
+	if err = t.jumpAddress(ivt.Self); err != nil {
+		return fmt.Errorf("failed to set jump address: %v", err)
+	}
+
+	klog.Infof("✅ Serial download on %s complete", t.DeviceInfo.Path)
+	return nil
+}
+
+func (t *Target) sendHIDReport(n int, buf []byte, wait int) ([]byte, error) {
+	if err := t.dev.Write(append([]byte{byte(n)}, buf...)); err != nil {
+		return nil, fmt.Errorf("failed to send HID report to device (%v): %v", t.DeviceInfo.Path, err)
+	}
+	if wait < 0 {
+		return nil, nil
+	}
+
+	for {
+		select {
+		case res, ok := <-t.dev.ReadCh():
+			if !ok {
+				return nil, errors.New("error reading response")
+			}
+
+			if len(res) > 0 && res[0] == byte(wait) {
+				return res, nil
+			}
+		case <-time.After(Timeout):
+			return nil, errors.New("command timeout")
+		}
+	}
+}
+
+func (t *Target) dcdWrite(dcd []byte, addr uint32) error {
+	r1, r2 := sdp.BuildDCDWriteReport(dcd, addr)
+
+	if _, err := t.sendHIDReport(1, r1, -1); err != nil {
+		return fmt.Errorf("failed to send first DCD write report: %v", err)
+	}
+
+	if _, err := t.sendHIDReport(2, r2, 4); err != nil {
+		return fmt.Errorf("failed to send second DCD write report: %v", err)
+	}
+
+	return nil
+}
+
+func (t *Target) fileWrite(imx []byte, addr uint32) error {
+	r1, r2 := sdp.BuildFileWriteReport(imx, addr)
+
+	if _, err := t.sendHIDReport(1, r1, -1); err != nil {
+		return fmt.Errorf("failed to send FileWriteReport r1: %v", err)
+	}
+
+	wait := -1
+
+	for i, r := range r2 {
+		if i == len(r2)-1 {
+			wait = 4
+		}
+	send:
+		_, err := t.sendHIDReport(2, r, wait)
+		if err != nil && runtime.GOOS == "darwin" && err.Error() == "hid: general error" {
+			// On macOS access contention with the OS causes
+			// errors, as a workaround we retry from the transfer
+			// that got caught up.
+			select {
+			case <-time.After(Timeout):
+				return err
+			default:
+				off := uint32(i) * 1024
+				r1 := &sdp.SDP{
+					CommandType: sdp.WriteFile,
+					Address:     addr + off,
+					DataCount:   uint32(len(imx)) - off,
+				}
+
+				if _, err = t.sendHIDReport(1, r1.Bytes(), -1); err != nil {
+					return fmt.Errorf("(retry) failed to send FileWriteReport r1 file bytes at 0x%x: %v", r1.Address, err)
+				}
+
+				goto send
+			}
+		}
+
+		if err != nil {
+			return fmt.Errorf("failed to send FileWriteReport r2[%d]: %v", i, err)
+		}
+	}
+
+	return nil
+}
+
+func (t *Target) jumpAddress(addr uint32) error {
+	r1 := sdp.BuildJumpAddressReport(addr)
+	if _, err := t.sendHIDReport(1, r1, -1); err != nil {
+		return fmt.Errorf("failed to send JumpAddressReport: %v", err)
+	}
+
+	return nil
+}

--- a/cmd/provision/sdp.go
+++ b/cmd/provision/sdp.go
@@ -24,7 +24,7 @@ import (
 	"time"
 
 	"github.com/usbarmory/armory-boot/sdp"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 
 	"github.com/usbarmory/hid"
 )

--- a/cmd/provision/sdp.go
+++ b/cmd/provision/sdp.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Large portions of this file come from github.com/armory-boot/cmd/armory-boot-usb.
+// Large portions of this file come from
+// https://github.com/usbarmory/armory-boot/blob/master/cmd/armory-boot-usb/armory-boot-usb.go
 
 package main
 

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,14 @@ module github.com/transparency-dev/armored-witness
 
 go 1.20
 
-require k8s.io/klog v1.0.0
+require (
+	github.com/fsnotify/fsnotify v1.6.0
+	github.com/usbarmory/armory-boot v0.0.0-20230808204644-0ff24f2da486
+	github.com/usbarmory/hid v0.0.0-20210318233634-85ced88a1ffe
+	k8s.io/klog/v2 v2.100.1
+)
+
+require (
+	github.com/go-logr/logr v1.2.0 // indirect
+	golang.org/x/sys v0.11.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,13 @@
-github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
-k8s.io/klog v1.0.0 h1:Pt+yjF5aB1xDSVbau4VsWe+dQNzA0qv1LlXdC2dF6Q8=
-k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
+github.com/go-logr/logr v1.2.0 h1:QK40JKJyMdUDz+h+xvCsru/bJhvG0UxvePV0ufL/AcE=
+github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+k8s.io/klog/v2 v2.100.1 h1:7WCHKK6K8fNhTqfBhISHQ97KrnJNFZMcQvKp7gP/tmg=
+k8s.io/klog/v2 v2.100.1/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=
+github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
+github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
+github.com/usbarmory/armory-boot v0.0.0-20230808204644-0ff24f2da486 h1:5jMcsK5ZhRlRd2NgbAPqhxbebymv2YmQ/UVVsjL/PJk=
+github.com/usbarmory/armory-boot v0.0.0-20230808204644-0ff24f2da486/go.mod h1:20DIzHJntbLDOptGT7TOm8DkT5mL2jRyzPzVXAYVHJ8=
+github.com/usbarmory/hid v0.0.0-20210318233634-85ced88a1ffe h1:WWop+y0QNxBEZAKu9xlNiZWgo5+y5VkzlyngVMViBlE=
+github.com/usbarmory/hid v0.0.0-20210318233634-85ced88a1ffe/go.mod h1:8ScVLh9aty8MLtypACxU7JdF5u2y2rEfhx3zJPS/tPc=
+golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.11.0 h1:eG7RXZHdqOJ1i+0lgLgCpSXAp6M3LYlAo6osgSi0xOM=
+golang.org/x/sys v0.11.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
This allows the provision tool to:
 - automatically discover any plugged in but un-provisioned devices
 - boot the device into the `armory-ums` recovery image
 - wait for the device to reappear and figure out which block device it's mapped to.