### PR TITLE
Use cobra for subcommands in manifest

### DIFF
--- a/cmd/manifest/cmd/create.go
+++ b/cmd/manifest/cmd/create.go
@@ -1,0 +1,117 @@
+// Copyright 2023 The Armored Witness authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cmd
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/coreos/go-semver/semver"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/transparency-dev/armored-witness-common/release/firmware/ftlog"
+	"golang.org/x/exp/maps"
+)
+
+// createCmd represents the create command
+var (
+	createCmd = &cobra.Command{
+		Use:   "create",
+		Short: "Create a new manifest file",
+		Long:  `This command is used to create a new firmware manifest file.\n\nThe manifest describes important details about the firmware. `,
+		Run:   create,
+	}
+
+	// knownFirmwareTypes is the set of possible values for the firmware_type flag.
+	knownFirmwareTypes = map[string]struct{}{
+		ftlog.ComponentApplet:   {},
+		ftlog.ComponentBoot:     {},
+		ftlog.ComponentOS:       {},
+		ftlog.ComponentRecovery: {},
+	}
+)
+
+func init() {
+	rootCmd.AddCommand(createCmd)
+
+	createCmd.Flags().String("git_tag", "", "The semantic version of the Trusted Applet release.")
+	createCmd.Flags().String("git_commit_fingerprint", "", "Hex-encoded SHA-1 commit hash of the git repository when checked out at the specified git_tag.")
+	createCmd.Flags().String("firmware_file", "", "Path of the firmware ELF file. ")
+	createCmd.Flags().String("tamago_version", "", "The version of the Tamago (https://github.com/usbarmory/tamago) used to compile the Trusted Applet.")
+	createCmd.Flags().String("output_file", "", "The file to write the manifest to. If this is not set, then only print the manifest to stdout.")
+	createCmd.Flags().String("firmware_type", "", fmt.Sprintf("One of %v ", maps.Keys(knownFirmwareTypes)))
+}
+
+func create(cmd *cobra.Command, args []string) {
+	gitTag := requireFlagString(cmd.Flags(), "git_tag")
+	gitCommitFingerprint := requireFlagString(cmd.Flags(), "git_commit_fingerprint")
+	firmwareFile := requireFlagString(cmd.Flags(), "firmware_file")
+	tamagoVersion := requireFlagString(cmd.Flags(), "tamago_version")
+	firmwareType := requireFlagString(cmd.Flags(), "firmware_type")
+	if _, ok := knownFirmwareTypes[firmwareType]; !ok {
+		log.Fatalf("firmware_type must be one of %v", maps.Keys(knownFirmwareTypes))
+	}
+
+	firmwareBytes, err := os.ReadFile(firmwareFile)
+	if err != nil {
+		log.Fatalf("Failed to read firmware_file %q: %v", firmwareFile, err)
+	}
+	digestBytes := sha256.Sum256(firmwareBytes)
+
+	gitTagName, err := semver.NewVersion(gitTag)
+	if err != nil {
+		log.Fatalf("Failed to parse git_tag: %v", err)
+	}
+	tamagoVersionName, err := semver.NewVersion(tamagoVersion)
+	if err != nil {
+		log.Fatalf("Failed to parse tamago_version: %v", err)
+	}
+	r := ftlog.FirmwareRelease{
+		Component:            firmwareType,
+		GitTagName:           *gitTagName,
+		GitCommitFingerprint: gitCommitFingerprint,
+		FirmwareDigestSha256: digestBytes[:],
+		TamagoVersion:        *tamagoVersionName,
+	}
+	b, err := json.MarshalIndent(r, "", "  ")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println(string(b))
+
+	outputFile, _ := cmd.Flags().GetString("output_file")
+	if outputFile == "" {
+		return
+	}
+	if err := os.WriteFile(outputFile, b, 0664); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func requireFlagString(f *pflag.FlagSet, name string) string {
+	v, err := f.GetString(name)
+	if err != nil {
+		log.Fatalf("Getting flag %v: %v", name, err)
+	}
+	if v == "" {
+		log.Fatalf("Flag %v must be speficied", name)
+	}
+	return v
+}

--- a/cmd/manifest/cmd/root.go
+++ b/cmd/manifest/cmd/root.go
@@ -1,0 +1,43 @@
+/// Copyright 2023 The Armored Witness authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// Package cmd contains commands for the manifest tool.
+package cmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// rootCmd represents the base command when called without any subcommands
+var rootCmd = &cobra.Command{
+	Use:   "manifest",
+	Short: "A tool for working with firmware manifest files",
+	Long: `Manifest is a tool for working with firmware manifest files.
+
+Manifest files contain important information about firmware releases, and
+are intended to be stored in firmware transparency logs, and consumed by
+verifiers and tools/devices involved in the provision and update process.`,
+}
+
+// Execute adds all child commands to the root command and sets flags appropriately.
+// This is called by main.main(). It only needs to happen once to the rootCmd.
+func Execute() {
+	err := rootCmd.Execute()
+	if err != nil {
+		os.Exit(1)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,9 @@ require (
 	github.com/go-errors/errors v1.4.2 // indirect
 	github.com/go-logr/logr v1.2.0 // indirect
 	github.com/gsora/fidati v0.0.0-20220824075547-eeb0a5f7d6c3 // indirect
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/cobra v1.7.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/transparency-dev/formats v0.0.0-20230920083814-0f75b1d4e813 // indirect
 	github.com/transparency-dev/merkle v0.0.2 // indirect
 	github.com/usbarmory/tamago v0.0.0-20230814171810-6cd63c1accf5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,6 @@
 github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr4=
 github.com/coreos/go-semver v0.3.1/go.mod h1:irMmmIw/7yzSRPWryHsK7EYSg09caPQL03VsM8rvUec=
+github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dsoprea/go-ext4 v0.0.0-20190528173430-c13b09fc0ff8 h1:e3CYZInWqO0a3MWfD0WW/11Ki0qo3Fc1ZAHx0+whlhY=
@@ -22,9 +23,16 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/gsora/fidati v0.0.0-20220824075547-eeb0a5f7d6c3 h1:klG3scbSLaGIvJO1p9wdTaHonsCSAcvNrX8vfa8LRd4=
 github.com/gsora/fidati v0.0.0-20220824075547-eeb0a5f7d6c3/go.mod h1:pqELFmXT+lU57T8pIGwPSOODIvRv/r/lwxlJX0UupvY=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rakyll/statik v0.1.7/go.mod h1:AlZONWzMtEnMs7W4e/1LURLiI49pIMmp6V9Unghqrcc=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.7.0 h1:hyqWnYt1ZQShIddO5kBpj3vu05/++x6tJ6dg8EC572I=
+github.com/spf13/cobra v1.7.0/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRMrb0=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=


### PR DESCRIPTION
This PR adds a `create` subcommand to the `manifest` tool using the `cobra` package, and moves over the implementation into its new location.