### PR TITLE
Adds support for signing & verifying signatures to the manifest tool

### DIFF
--- a/cmd/manifest/cmd/create.go
+++ b/cmd/manifest/cmd/create.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"strings"
 
 	"github.com/coreos/go-semver/semver"
 	"github.com/spf13/cobra"
@@ -105,6 +104,8 @@ func create(cmd *cobra.Command, args []string) {
 	if err != nil {
 		log.Fatal(err)
 	}
+	// Note requires the msg ends in a newline.
+	b = append(b, byte('\n'))
 
 	if !raw {
 		signer := requireFlagString(cmd.Flags(), "private_key")
@@ -114,7 +115,7 @@ func create(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	fmt.Println(string(b))
+	fmt.Print(string(b))
 
 	outputFile, _ := cmd.Flags().GetString("output_file")
 	if outputFile == "" {
@@ -142,9 +143,5 @@ func sign(sec string, b []byte) ([]byte, error) {
 		return nil, err
 	}
 	t := string(b)
-	// Note requires that the text ends in a final newline.
-	if !strings.HasSuffix(t, "\n") {
-		t += "\n"
-	}
 	return note.Sign(&note.Note{Text: t}, signer)
 }

--- a/cmd/manifest/cmd/root.go
+++ b/cmd/manifest/cmd/root.go
@@ -1,4 +1,4 @@
-/// Copyright 2023 The Armored Witness authors. All Rights Reserved.
+// Copyright 2023 The Armored Witness authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/manifest/cmd/verifysig.go
+++ b/cmd/manifest/cmd/verifysig.go
@@ -36,17 +36,21 @@ func init() {
 	rootCmd.AddCommand(verifysigCmd)
 
 	verifysigCmd.Flags().String("input_file", "", "The file to read the signed manifest from. If this is not set, then read the manifest from stdin.")
-	verifysigCmd.Flags().String("public_key", "", "Note-formatted verifier string, used to verify the signature on the manifest")
+	verifysigCmd.Flags().String("public_key_file", "", "Note-formatted verifier string, used to verify the signature on the manifest")
 }
 
 func verify(cmd *cobra.Command, args []string) {
-	pubK := requireFlagString(cmd.Flags(), "public_key")
-	verifier, err := note.NewVerifier(pubK)
+	pubKFile := requireFlagString(cmd.Flags(), "public_key_file")
+	pubK, err := os.ReadFile(pubKFile)
+	if err != nil {
+		log.Fatalf("Failed to read public key file: %v", err)
+	}
+	verifier, err := note.NewVerifier(string(pubK))
 	if err != nil {
 		log.Fatalf("Invalid public key: %v", err)
 	}
 
-	msg := []byte{}
+	var msg []byte
 	input, _ := cmd.Flags().GetString("input_file")
 	if input == "" {
 		msg, err = io.ReadAll(os.Stdin)

--- a/cmd/manifest/cmd/verifysig.go
+++ b/cmd/manifest/cmd/verifysig.go
@@ -1,0 +1,64 @@
+// Copyright 2023 The Armored Witness authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cmd
+
+import (
+	"io"
+	"log"
+	"os"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/mod/sumdb/note"
+)
+
+// verifysigCmd represents the verifysig command
+var verifysigCmd = &cobra.Command{
+	Use:   "verifysig",
+	Short: "Verify a manifest has a valid signature from a given key",
+	Long:  `This command verifies that a manifest is signed by a specific public key.\n\nTo check that valid signatures from multiple keys are present, re-run this command with each of the public keys in turn`,
+	Run:   verify,
+}
+
+func init() {
+	rootCmd.AddCommand(verifysigCmd)
+
+	verifysigCmd.Flags().String("input_file", "", "The file to read the signed manifest from. If this is not set, then read the manifest from stdin.")
+	verifysigCmd.Flags().String("public_key", "", "Note-formatted verifier string, used to verify the signature on the manifest")
+}
+
+func verify(cmd *cobra.Command, args []string) {
+	pubK := requireFlagString(cmd.Flags(), "public_key")
+	verifier, err := note.NewVerifier(pubK)
+	if err != nil {
+		log.Fatalf("Invalid public key: %v", err)
+	}
+
+	msg := []byte{}
+	input, _ := cmd.Flags().GetString("input_file")
+	if input == "" {
+		msg, err = io.ReadAll(os.Stdin)
+	} else {
+		input = "<stdin>"
+		msg, err = os.ReadFile(input)
+	}
+	if err != nil {
+		log.Fatalf("Failed to read manifest from %v: %v", input, err)
+	}
+	if _, err = note.Open(msg, note.VerifierList(verifier)); err != nil {
+		log.Fatalf("Failed to open manifest: %v", err)
+	}
+	log.Println("Manifest signature verified ok")
+}


### PR DESCRIPTION
This PR adds support for signing & verifying manifests using the `note` format.

A `--raw` flag is added which maintains the old behaviour of simply writing out an unsigned manifest` for compatibility with infrastructure where signing would be a separate step.

Tested:
```
❯ go run ./cmd/manifest create \
        --git_tag=0.0.0+4abca8f9744d4f3d566062bdd03d400135b3c3a0 \
        --git_commit_fingerprint="4abca8f" \
        --firmware_file=/home/al/usbarmory/armored-witness-boot/armored-witness-boot.imx \
        --firmware_type=BOOTLOADER \
        --tamago_version=1.21.0 \
      --private_key_file=$LOG_PRIVATE_KEY | go run ./cmd/manifest verifysig --public_key_file=$LOG_PUBLIC_KEY
2023/09/28 14:39:04 Manifest signature verified ok
```

Builds on #21.