### PR TITLE
Bake KMS configs into signing tool

### DIFF
--- a/pkg/kmssigner/kmssigner.go
+++ b/pkg/kmssigner/kmssigner.go
@@ -6,7 +6,7 @@ import (
 	"encoding/binary"
 	"encoding/pem"
 
-	"cloud.google.com/go/kms/apiv1"
+	kms "cloud.google.com/go/kms/apiv1"
 
 	"cloud.google.com/go/kms/apiv1/kmspb"
 )
@@ -38,16 +38,16 @@ type Signer struct {
 // expected to be
 // [Ed25519](https://pkg.go.dev/golang.org/x/mod/sumdb/note#hdr-Generating_Keys).
 // To open a note signed by this Signer, the verifier must also be Ed25519.
-func New(ctx context.Context, c *kms.KeyManagementClient, keyName string) (*Signer, error) {
+func New(ctx context.Context, c *kms.KeyManagementClient, keyResource, noteSignerName string) (*Signer, error) {
 	s := &Signer{}
 
 	s.client = c
 	s.ctx = ctx
-	s.keyName = keyName
+	s.keyName = noteSignerName
 
 	// Set keyHash.
 	req := &kmspb.GetPublicKeyRequest{
-		Name: s.keyName,
+		Name: keyResource,
 	}
 	resp, err := c.GetPublicKey(ctx, req)
 	if err != nil {

--- a/pkg/kmssigner/kmssigner.go
+++ b/pkg/kmssigner/kmssigner.go
@@ -28,10 +28,11 @@ type Signer struct {
 	// ctx must be stored because Signer is used as an implementation of the
 	// note.Signer interface, which does not allow for a context in the Sign
 	// method. However, the KMS AsymmetricSign API requires a context.
-	ctx     context.Context
-	client  *kms.KeyManagementClient
-	keyHash uint32
-	keyName string
+	ctx         context.Context
+	client      *kms.KeyManagementClient
+	keyHash     uint32
+	keyName     string
+	keyResource string
 }
 
 // New creates a signer which uses keys in GCP KMS. The signing algorithm is
@@ -44,6 +45,7 @@ func New(ctx context.Context, c *kms.KeyManagementClient, keyResource, noteSigne
 	s.client = c
 	s.ctx = ctx
 	s.keyName = noteSignerName
+	s.keyResource = keyResource
 
 	// Set keyHash.
 	req := &kmspb.GetPublicKeyRequest{
@@ -81,7 +83,7 @@ func (s *Signer) KeyHash() uint32 {
 // Sign returns a signature for the given message.
 func (s *Signer) Sign(msg []byte) ([]byte, error) {
 	req := &kmspb.AsymmetricSignRequest{
-		Name: s.keyName,
+		Name: s.keyResource,
 		Data: msg,
 	}
 	resp, err := s.client.AsymmetricSign(s.ctx, req)


### PR DESCRIPTION
This PR makes the `sign` tool more tightly bound to its usage in signing FT artefacts for the armored witness project.

It "bakes in" much of the KMS config, and explicitly binds public keys to the expected signing key - verifying that created signatures can be verified correctly before writing them out.
This should make it harder for accidents to occur.