### PR TITLE
Bump a-w-common to eefcf9dd7f27a07993d1cf612ab3e798d08d316e

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5
 	github.com/transparency-dev/armored-witness-boot v0.0.0-20231011120056-79f8a7e1e0c8
-	github.com/transparency-dev/armored-witness-common v0.0.0-20231027110430-3802c9e3e15d
+	github.com/transparency-dev/armored-witness-common v0.0.0-20231031160117-eefcf9dd7f27
 	github.com/transparency-dev/armored-witness-os v0.0.0-20231010171114-e1c1c28a17ff
 	github.com/transparency-dev/formats v0.0.0-20230920083814-0f75b1d4e813
 	github.com/transparency-dev/merkle v0.0.2

--- a/go.sum
+++ b/go.sum
@@ -105,8 +105,6 @@ github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ
 github.com/transparency-dev/armored-witness-applet v0.0.0-20230918140527-29dcafed830b h1:d8bLTgqLrvH1VJyNUTAzLyY/Ux13s7QHb19vEcTum7E=
 github.com/transparency-dev/armored-witness-boot v0.0.0-20231011120056-79f8a7e1e0c8 h1:pvj67GFYya9xrWliTdJ/7pqYb7uU3uzW2Y9Al5jmuD8=
 github.com/transparency-dev/armored-witness-boot v0.0.0-20231011120056-79f8a7e1e0c8/go.mod h1:TDJ6CudBun//r3Fcat5oDNifKZ7D52LzBCqLAiqJjzw=
-github.com/transparency-dev/armored-witness-common v0.0.0-20231027110430-3802c9e3e15d h1:76yBTOSuqGXpKe7qjF1Yjzf4MOhXYryeVObzUkpKHf0=
-github.com/transparency-dev/armored-witness-common v0.0.0-20231027110430-3802c9e3e15d/go.mod h1:6M39UQVYzzFdzXGrJFjRC+G9D5f0icxOVkcX/yaWZss=
 github.com/transparency-dev/armored-witness-common v0.0.0-20231031160117-eefcf9dd7f27 h1:p8mmHwCvTYbuB52ph9knjwWkQmGNZ+3BZJgsw9xIQq0=
 github.com/transparency-dev/armored-witness-common v0.0.0-20231031160117-eefcf9dd7f27/go.mod h1:6M39UQVYzzFdzXGrJFjRC+G9D5f0icxOVkcX/yaWZss=
 github.com/transparency-dev/armored-witness-os v0.0.0-20231010171114-e1c1c28a17ff h1:k0eXnAwr1BeuYcf/Fajfjbd9vQSOY0Xk21+qp+FYNZo=

--- a/go.sum
+++ b/go.sum
@@ -107,6 +107,8 @@ github.com/transparency-dev/armored-witness-boot v0.0.0-20231011120056-79f8a7e1e
 github.com/transparency-dev/armored-witness-boot v0.0.0-20231011120056-79f8a7e1e0c8/go.mod h1:TDJ6CudBun//r3Fcat5oDNifKZ7D52LzBCqLAiqJjzw=
 github.com/transparency-dev/armored-witness-common v0.0.0-20231027110430-3802c9e3e15d h1:76yBTOSuqGXpKe7qjF1Yjzf4MOhXYryeVObzUkpKHf0=
 github.com/transparency-dev/armored-witness-common v0.0.0-20231027110430-3802c9e3e15d/go.mod h1:6M39UQVYzzFdzXGrJFjRC+G9D5f0icxOVkcX/yaWZss=
+github.com/transparency-dev/armored-witness-common v0.0.0-20231031160117-eefcf9dd7f27 h1:p8mmHwCvTYbuB52ph9knjwWkQmGNZ+3BZJgsw9xIQq0=
+github.com/transparency-dev/armored-witness-common v0.0.0-20231031160117-eefcf9dd7f27/go.mod h1:6M39UQVYzzFdzXGrJFjRC+G9D5f0icxOVkcX/yaWZss=
 github.com/transparency-dev/armored-witness-os v0.0.0-20231010171114-e1c1c28a17ff h1:k0eXnAwr1BeuYcf/Fajfjbd9vQSOY0Xk21+qp+FYNZo=
 github.com/transparency-dev/armored-witness-os v0.0.0-20231010171114-e1c1c28a17ff/go.mod h1:PgW6IUerAQ4dmjzs/oa+Fv25c+Rt4JwBzA/p04bLafE=
 github.com/transparency-dev/formats v0.0.0-20230920083814-0f75b1d4e813 h1:PHklaeYyhPsbhWt+MnKpBvJrsJGkPEaU1JutMj4wNqM=


### PR DESCRIPTION
This allows the tooling here to access firmware stored in the new CAS location.

See https://github.com/transparency-dev/armored-witness-common/pull/15