### PR TITLE
Add Terraform config for a-w networking services.

### DIFF
--- a/deployment/main.tf
+++ b/deployment/main.tf
@@ -17,6 +17,9 @@ module "lb-http" {
   ssl                             = var.tls
   managed_ssl_certificate_domains = [var.serve_domain]
   https_redirect                  = var.tls
+  
+  create_ipv6_address             = true
+  enable_ipv6                     = true
 
   backends = {
     default = {

--- a/deployment/main.tf
+++ b/deployment/main.tf
@@ -33,8 +33,8 @@ module "lb-http" {
         }
       ]
 
-      health_check = null
-
+    health_check = null
+    
       enable_cdn = false
 
       iap_config = {
@@ -68,7 +68,6 @@ resource "google_compute_url_map" "default" {
   path_matcher {
     name = "allpaths"
 
-    /*
     # If we don't know what this is, send them to the website.
     default_url_redirect {
       https_redirect = true
@@ -82,13 +81,15 @@ resource "google_compute_url_map" "default" {
 
     path_rule {
       paths = [
-        "/*"
+        "/distributor/*"
       ]
+      route_action {
+        url_rewrite {
+          host_rewrite = var.distributor_host
+        }
+      }
       service = module.lb-http.backend_services["default"].id
     }
-    */
-
-    default_service = module.lb-http.backend_services["default"].id
 
     #####
     # CI log & aretefacts rules
@@ -103,7 +104,6 @@ resource "google_compute_url_map" "default" {
       }
       service = google_compute_backend_bucket.firmware_log_ci.id
     }
-
     path_rule {
       paths = [
         "/armored-witness-firmware/ci/artefacts/0/*"
@@ -136,6 +136,7 @@ resource "google_compute_backend_bucket" "firmware_artefacts_ci" {
 
 resource "google_compute_global_network_endpoint_group" "distributor" {
   name                  = "distributor"
+  provider              = google-beta
   default_port          = var.distributor_port
   network_endpoint_type = "INTERNET_FQDN_PORT"
 }

--- a/deployment/main.tf
+++ b/deployment/main.tf
@@ -1,0 +1,144 @@
+provider "google" {
+  project = var.project_id
+}
+
+data "google_project" "project" {
+  project_id = var.project_id
+}
+
+module "lb-http" {
+  source = "GoogleCloudPlatform/lb-http/google//modules/serverless_negs"
+  version = "~> 9.0"
+
+  name                  = var.lb_name
+  project               = var.project_id
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+
+  ssl                             = var.tls
+  managed_ssl_certificate_domains = [var.serve_domain]
+  https_redirect                  = var.tls
+
+  backends = {
+    default = {
+      description = "Distributor API backend"
+      protocol    = "HTTPS"
+      port_name   = "https"
+      port        = 443
+      groups = [
+        {
+          group = google_compute_global_network_endpoint_group.distributor.id
+        }
+      ]
+
+      health_check = null
+
+      enable_cdn = false
+
+      iap_config = {
+        enable = false
+      }
+      log_config = {
+        enable = false
+      }
+    }
+  }
+
+  create_url_map = false
+  url_map        = google_compute_url_map.default.self_link
+}
+
+resource "google_compute_url_map" "default" {
+  name = "api-transparency-dev-url-map"
+
+  default_url_redirect {
+    https_redirect = true
+    host_redirect  = "transparency.dev"
+    path_redirect  = "/"
+    strip_query    = true
+  }
+
+  host_rule {
+    hosts        = [var.serve_domain]
+    path_matcher = "allpaths"
+  }
+
+  path_matcher {
+    name = "allpaths"
+
+    /*
+    # If we don't know what this is, send them to the website.
+    default_url_redirect {
+      https_redirect = true
+      host_redirect  = "transparency.dev"
+      path_redirect  = "/"
+      strip_query    = true
+    }
+
+    #####
+    # Distributor rules
+
+    path_rule {
+      paths = [
+        "/*"
+      ]
+      service = module.lb-http.backend_services["default"].id
+    }
+    */
+
+    default_service = module.lb-http.backend_services["default"].id
+
+    #####
+    # CI log & aretefacts rules
+    path_rule {
+      paths = [
+        "/armored-witness-firmware/ci/log/0/*"
+      ]
+      route_action {
+        url_rewrite {
+          path_prefix_rewrite = "/"
+        }
+      }
+      service = google_compute_backend_bucket.firmware_log_ci.id
+    }
+
+    path_rule {
+      paths = [
+        "/armored-witness-firmware/ci/artefacts/0/*"
+      ]
+      route_action {
+        url_rewrite {
+          path_prefix_rewrite = "/"
+        }
+      }
+      service = google_compute_backend_bucket.firmware_artefacts_ci.id
+    }
+
+    # TODO(prod logs & artefacts)
+  }
+}
+
+resource "google_compute_backend_bucket" "firmware_log_ci" {
+  name        = "firmware-log-ci-backend"
+  description = "Contains CI firmware transparency log"
+  bucket_name = var.bucket_firmware_log_ci
+  enable_cdn = false
+}
+
+resource "google_compute_backend_bucket" "firmware_artefacts_ci" {
+  name        = "firmware-artefacts-ci-backend"
+  description = "Contains CI firmware artefacts"
+  bucket_name = var.bucket_firmware_artefacts_ci
+  enable_cdn = false
+}
+
+resource "google_compute_global_network_endpoint_group" "distributor" {
+  name                  = "distributor"
+  default_port          = var.distributor_port
+  network_endpoint_type = "INTERNET_FQDN_PORT"
+}
+
+resource "google_compute_global_network_endpoint" "distributor" {
+  global_network_endpoint_group = google_compute_global_network_endpoint_group.distributor.name
+  port                          = var.distributor_port
+  fqdn                          = var.distributor_host
+}

--- a/deployment/terraform.tfvars
+++ b/deployment/terraform.tfvars
@@ -1,0 +1,13 @@
+project_id = "1071548024491"
+region     = "global"
+
+tls          = true
+serve_domain = "api.transparency.dev"
+
+lb_name = "transparency-dev-lb"
+
+bucket_firmware_artefacts_ci = "armored-witness-firmware-ci"
+bucket_firmware_log_ci       = "armored-witness-firmware-log-ci"
+
+distributor_host = "distributor-service-oxxl2d5jeq-uc.a.run.app"
+distributor_port = 443

--- a/deployment/tls.tf
+++ b/deployment/tls.tf
@@ -1,0 +1,8 @@
+resource "google_compute_managed_ssl_certificate" "lb_default" {
+  provider = google-beta
+  name     = "transparency-dev-ssl-cert"
+
+  managed {
+    domains = [var.serve_domain]
+  }
+}

--- a/deployment/variables.tf
+++ b/deployment/variables.tf
@@ -1,0 +1,37 @@
+variable "project_id" {
+  description = "The project ID to host the cluster in"
+}
+
+variable "region" {
+  description = "The region to host the cluster in"
+}
+
+variable "serve_domain" {
+  description = "The domain we'll use to serve"
+  type        = string
+}
+
+variable "tls" {
+  description = "Enable TLS"
+  type        = bool
+}
+
+variable "bucket_firmware_log_ci" {
+  description = "Bucket name for CI firmware log data"
+}
+
+variable "bucket_firmware_artefacts_ci" {
+  description = "Bucket name for CI firmware artefact data"
+}
+
+variable "distributor_host" {
+  description = "Host name serving distributor service API"
+}
+variable "distributor_port" {
+  description = "Port on distributor_host where distributor service API is served"
+  type        = number
+}
+
+variable "lb_name" {
+  description = "Name of the load balancer"
+}


### PR DESCRIPTION
This PR adds terraform config which will expose endpoints under `https://api.transparency.dev` for:
- The checkpoint distributor
- The CI FirmwareTransparency log
- The firmware artefacts referenced by the CI FirmwareTransparency log