### PR TITLE
Add .gitignore for buildable binaries in this repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/manifest
+/provision
+/sign
+/verify
+


### PR DESCRIPTION
This avoids accidentally checking in one of the built executables, and keeps git status cleaner the rest of the time.
