### PR TITLE
Reproducible build verifier for armored witness components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 /provision
 /sign
 /verify
+/build
 

--- a/verifier/build/Dockerfile
+++ b/verifier/build/Dockerfile
@@ -1,0 +1,45 @@
+# This Dockerfile builds an image with all the tools needed to
+# build armory-drive. The entrypoint will run a monitor that
+# reproduces the builds from the armory-drive-log.
+FROM golang:1.21-alpine AS builder
+
+ARG GOFLAGS=""
+ENV GOFLAGS=$GOFLAGS
+ENV GO111MODULE=on
+
+# Move to working directory /build
+WORKDIR /build
+
+# Copy and download dependency using go mod
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+
+# Copy the code into the container
+COPY . .
+
+# Build the application
+RUN go build -o /build/bin/monitor ./verifier/build
+
+#
+# Set up the final image
+#
+FROM ubuntu:18.04
+
+RUN apt-get update
+RUN apt-get -y install curl unzip wget xxd git
+
+# Tamago requirements (versions of tamago will be installed at runtime)
+RUN apt-get -y install binutils-arm-none-eabi build-essential make u-boot-tools musl-tools
+
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:/testbase/protoc/bin:/usr/local/go/bin:$PATH
+
+# Set up the proto compilation stuff
+RUN cd /usr && \
+    wget "https://github.com/google/protobuf/releases/download/v3.12.4/protoc-3.12.4-linux-x86_64.zip" && \
+    unzip "protoc-3.12.4-linux-x86_64.zip"
+
+COPY --from=builder /build/bin/monitor /bin/monitor
+
+ENTRYPOINT ["/bin/monitor", "--alsologtostderr", "--state_file=/tmp/state"]

--- a/verifier/build/Dockerfile
+++ b/verifier/build/Dockerfile
@@ -24,7 +24,7 @@ RUN go build -o /build/bin/monitor ./verifier/build
 #
 # Set up the final image
 #
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 
 RUN apt-get update
 RUN apt-get -y install curl unzip wget xxd git

--- a/verifier/build/README.md
+++ b/verifier/build/README.md
@@ -1,0 +1,25 @@
+# Reproducible Build Verifier
+
+This continuously monitors the log to look for claims about builds being published.
+The log properties are checked to ensure the log is consistent with any previous
+view, and that all claims are verifiably committed to by the log.
+
+For each manifest claim that it hasn't seen before, the following steps are taken:
+ 1. The source repository is cloned at the release tag
+ 2. The git revision at the tag is checked against the manifest
+ 3. The imx file is compiled from source
+ 4. The hash for the imx in the manifest is compared against the locally built version
+
+## Running
+
+In order to control the environment in which the code will be built,
+a Dockerfile is supplied which will create a compatible environment.
+
+This image can be built and executed using the following commands
+from the root of the repository:
+
+```bash
+docker build . -t armored-witness-build-verifier -f ./verifier/build/Dockerfile
+docker run armored-witness-build-verifier -v=1
+```
+

--- a/verifier/build/README.md
+++ b/verifier/build/README.md
@@ -5,10 +5,10 @@ The log properties are checked to ensure the log is consistent with any previous
 view, and that all claims are verifiably committed to by the log.
 
 For each manifest claim that it hasn't seen before, the following steps are taken:
- 1. The source repository is cloned at the release tag
+ 1. The source repository is cloned at the git commit hash
  2. The git revision at the tag is checked against the manifest
- 3. The imx file is compiled from source
- 4. The hash for the imx in the manifest is compared against the locally built version
+ 3. The ELF file is compiled from source
+ 4. The hash for the ELF in the manifest is compared against the locally built version
 
 ## Running
 

--- a/verifier/build/installer.go
+++ b/verifier/build/installer.go
@@ -1,0 +1,94 @@
+// Copyright 2023 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/coreos/go-semver/semver"
+	"k8s.io/klog/v2"
+)
+
+func newTamago(dir string) (Tamago, error) {
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		klog.V(1).Infof("Creating new tamago install directory at %s", dir)
+		if err := os.Mkdir(dir, os.ModeDir); err != nil {
+			return Tamago{}, err
+		}
+	}
+	return Tamago{
+		dir: dir,
+	}, nil
+}
+
+type Tamago struct {
+	dir string
+}
+
+// Switch ensures that the named version of Tamago is installed, or fails with
+// an error.
+func (t Tamago) Switch(v semver.Version) error {
+	vDir := filepath.Join(t.dir, v.String())
+	if _, err := os.Stat(vDir); os.IsNotExist(err) {
+		if err := t.install(v, vDir); err != nil {
+			return fmt.Errorf("failed to install tamago %s: %v", v, err)
+		}
+	}
+	goPath := filepath.Join(vDir, "bin", "go")
+	if _, err := os.Stat(goPath); os.IsNotExist(err) {
+		return fmt.Errorf("tamago version %q not available at %q: %v", v, goPath, err)
+	}
+	return nil
+}
+
+func (t Tamago) Envs(v semver.Version) []string {
+	vDir := filepath.Join(t.dir, v.String())
+	goPath := filepath.Join(vDir, "bin", "go")
+	return []string{
+		fmt.Sprintf("GOPATH=%s", vDir),
+		fmt.Sprintf("GOCACHE=%s/go-cache", t.dir),
+		fmt.Sprintf("TAMAGO=%s", goPath),
+	}
+}
+
+func (t Tamago) install(v semver.Version, dir string) error {
+	klog.Infof("Downloading and installing tamago %s", v)
+	u := fmt.Sprintf("https://github.com/usbarmory/tamago-go/releases/download/tamago-go%s/tamago-go%s.linux-amd64.tar.gz", v, v)
+	curl := exec.Command("curl", "-sfL", u)
+	tar := exec.Command("tar", "-xzf", "-", "-C", dir, "--strip-components", "3")
+	var err error
+	tar.Stdin, err = curl.StdoutPipe()
+	tar.Stdout = os.Stdout
+	if err != nil {
+		return err
+	}
+	if err := tar.Start(); err != nil {
+		return err
+	}
+	// Create the directory and then extract into it
+	if err := os.Mkdir(dir, os.ModeDir); err != nil {
+		return err
+	}
+	if err := curl.Run(); err != nil {
+		return err
+	}
+	if err := tar.Wait(); err != nil {
+		return err
+	}
+	klog.Infof("Installed tamago %s at %s", v, dir)
+	return nil
+}

--- a/verifier/build/main.go
+++ b/verifier/build/main.go
@@ -1,0 +1,345 @@
+// Copyright 2023 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// monitor starts a long-running process that will continually follow a log
+// for new checkpoints. All checkpoints are checked for consistency, and all
+// leaves in the tree will be downloaded, verified, and the release info
+// will be reproducibly verified.
+// This tool has a number of expectations of the environment, such as a working
+// tamago installation, git, and other make tooling. See the README and Dockerfile
+// in this directory for more details.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/transparency-dev/armored-witness-common/release/firmware/ftlog"
+	"github.com/transparency-dev/merkle/proof"
+	"github.com/transparency-dev/merkle/rfc6962"
+	"github.com/transparency-dev/serverless-log/client"
+	"golang.org/x/mod/sumdb/note"
+	"k8s.io/klog/v2"
+)
+
+var (
+	pollInterval        = flag.Duration("poll_interval", 1*time.Minute, "The interval at which the log will be polled for new data")
+	stateFile           = flag.String("state_file", "", "File path for where checkpoints should be stored")
+	distributorURL      = flag.String("distributor_url", "https://api.transparency.dev", "URL identifying the REST distributor")
+	logURL              = flag.String("log_url", "https://storage.googleapis.com/armored-witness-firmware-log-ci/", "URL identifying the location of the log")
+	binURL              = flag.String("bin_url", "https://storage.googleapis.com/armored-witness-firmware-ci/", "URL identifying the location of the binaries that are logged")
+	logOrigin           = flag.String("log_origin", "transparency.dev/armored-witness/firmware_transparency/ci/0", "The expected first line of checkpoints issued by the log")
+	logPubKey           = flag.String("log_pubkey", "transparency.dev-aw-ftlog-ci+f5479c1e+AR6gW0mycDtL17iM2uvQUThJsoiuSRirstEj9a5AdCCu", "The log's public key")
+	osReleasePubKey1    = flag.String("os_release_pubkey1", "transparency.dev-aw-os1-ci+7a0eaef3+AcsqvmrcKIbs21H2Bm2fWb6oFWn/9MmLGNc6NLJty2eQ", "The first OS release signer's public key")
+	osReleasePubKey2    = flag.String("os_release_pubkey2", "transparency.dev-aw-os2-ci+af8e4114+AbBJk5MgxRB+68KhGojhUdSt1ts5GAdRIT1Eq9zEkgQh", "The second OS release signer's public key")
+	appletReleasePubKey = flag.String("applet_release_pubkey", "transparency.dev-aw-applet-ci+3ff32e2c+AV1fgxtByjXuPjPfi0/7qTbEBlPGGCyxqr6ZlppoLOz3", "The applet release signer's public key")
+	cleanup             = flag.Bool("cleanup", true, "Set to false to keep git checkouts and make artifacts around after verification")
+	startIndex          = flag.Uint64("start_index", 0, "Used for debugging to start verifying leaves from a given index. Only used if there is no prior checkpoint available.")
+)
+
+func main() {
+	klog.InitFlags(nil)
+	flag.Parse()
+	defer klog.Flush()
+	ctx := context.Background()
+
+	st, isNew, err := stateTrackerFromFlags(ctx)
+	if err != nil {
+		klog.Exitf("Failed to create new LogStateTracker: %v", err)
+	}
+
+	tamago, err := newTamago("/usr/local/tamago-go")
+	if err != nil {
+		klog.Exitf("Failed to init tamago: %v", err)
+	}
+	sigStore := newReleaseSigStoreFromFlags()
+	defer sigStore.cleanup()
+
+	rbv, err := NewReproducibleBuildVerifier(*cleanup, tamago, sigStore)
+	if err != nil {
+		klog.Exitf("Failed to create reproducible build verifier: %v", err)
+	}
+
+	monitor := Monitor{
+		st:        st,
+		stateFile: *stateFile,
+		sigStore:  sigStore,
+		handler:   rbv.VerifyManifest,
+	}
+
+	if isNew {
+		klog.Infof("No previous checkpoint, starting at %d", *startIndex)
+		// This monitor has no memory of running before, so let's catch up with the log.
+		if err := monitor.From(ctx, *startIndex); err != nil {
+			klog.Exitf("monitor.From(%d): %v", 0, err)
+		}
+	}
+
+	klog.Info("No known backlog, switching mode to poll log for new checkpoints...")
+
+	// We've processed all leaves committed to by the tracker's checkpoint, and now we enter polling mode.
+	ticker := time.NewTicker(*pollInterval)
+	defer ticker.Stop()
+	for {
+		lastHead := st.LatestConsistent.Size
+		if _, _, _, err := st.Update(ctx); err != nil {
+			klog.Exitf("Failed to update checkpoint: %q", err)
+		}
+		if st.LatestConsistent.Size > lastHead {
+			klog.V(1).Infof("Found new checkpoint for tree size %d, fetching new leaves", st.LatestConsistent.Size)
+			if err := monitor.From(ctx, lastHead); err != nil {
+				klog.Exitf("monitor.From(%d): %v", lastHead, err)
+			}
+		} else {
+			klog.V(2).Infof("Polling: no new data found; tree size is still %d", st.LatestConsistent.Size)
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			// Go around the loop again.
+		}
+	}
+}
+
+// newReleaseSigStoreFromFlags returns a signature verifier constructed from the
+// flags, or dies trying.
+func newReleaseSigStoreFromFlags() releaseSigStore {
+	osReleaseVerifier1, err := note.NewVerifier(*osReleasePubKey1)
+	if err != nil {
+		klog.Exitf("Failed to construct OS release verifier: %v", err)
+	}
+	osReleaseVerifier2, err := note.NewVerifier(*osReleasePubKey2)
+	if err != nil {
+		klog.Exitf("Failed to construct OS release verifier: %v", err)
+	}
+	appletReleaseVerifier, err := note.NewVerifier(*appletReleasePubKey)
+	if err != nil {
+		klog.Exitf("Failed to construct applet release verifier: %v", err)
+	}
+	releaseVerifiers := note.VerifierList(osReleaseVerifier1, osReleaseVerifier2, appletReleaseVerifier)
+
+	dir, err := os.MkdirTemp("", "armored-witness-build-keys")
+	if err != nil {
+		klog.Exitf("Failed to create temp directory: %v", err)
+	}
+	logFile := filepath.Join(dir, "pubkey_log.pub")
+	os1File := filepath.Join(dir, "pubkey_os1.pub")
+	os2File := filepath.Join(dir, "pubkey_os2.pub")
+	appletFile := filepath.Join(dir, "pubkey_applet.pub")
+	if err := os.WriteFile(logFile, []byte(*logPubKey), 0644); err != nil {
+		klog.Exitf("Failed to create public key file: %v", err)
+	}
+	if err := os.WriteFile(os1File, []byte(*osReleasePubKey1), 0644); err != nil {
+		klog.Exitf("Failed to create public key file: %v", err)
+	}
+	if err := os.WriteFile(os2File, []byte(*osReleasePubKey2), 0644); err != nil {
+		klog.Exitf("Failed to create public key file: %v", err)
+	}
+	if err := os.WriteFile(appletFile, []byte(*appletReleasePubKey), 0644); err != nil {
+		klog.Exitf("Failed to create public key file: %v", err)
+	}
+
+	return releaseSigStore{
+		osV1: osReleaseVerifier1,
+		osV2: osReleaseVerifier2,
+		appV: appletReleaseVerifier,
+		allV: releaseVerifiers,
+		envs: []string{
+			fmt.Sprintf("REST_DISTRIBUTOR_BASE_URL=%s", *distributorURL),
+			fmt.Sprintf("FT_LOG_URL=%s", *logURL),
+			fmt.Sprintf("FT_BIN_URL=%s", *binURL),
+			fmt.Sprintf("LOG_ORIGIN=%s", *logOrigin),
+			fmt.Sprintf("LOG_PUBLIC_KEY=%s", logFile),
+			fmt.Sprintf("APPLET_PUBLIC_KEY=%s", appletFile),
+			fmt.Sprintf("OS_PUBLIC_KEY1=%s", os1File),
+			fmt.Sprintf("OS_PUBLIC_KEY2=%s", os2File),
+		},
+		cleanup: func() {
+			os.RemoveAll(dir)
+		},
+	}
+}
+
+// releaseSigStore stores the signatures used for verifying releases.
+// Having such an object avoids needing to pass lots of state as args, or parsing
+// keys in different places.
+type releaseSigStore struct {
+	osV1    note.Verifier
+	osV2    note.Verifier
+	appV    note.Verifier
+	allV    note.Verifiers
+	envs    []string
+	cleanup func()
+}
+
+// Monitor verifiably checks inclusion of all leaves in a range, and then passes the
+// parsed FirmwareRelease to a handler.
+type Monitor struct {
+	st        client.LogStateTracker
+	stateFile string
+	sigStore  releaseSigStore
+	handler   func(context.Context, uint64, ftlog.FirmwareRelease) error
+}
+
+// From checks the leaves from `start` up to the checkpoint from the state tracker.
+// Upon reaching the end of the leaves, the checkpoint is persisted in the state file.
+func (m *Monitor) From(ctx context.Context, start uint64) error {
+	fromCP := m.st.LatestConsistent
+	pb, err := client.NewProofBuilder(ctx, fromCP, m.st.Hasher.HashChildren, m.st.Fetcher)
+	if err != nil {
+		return fmt.Errorf("failed to construct proof builder: %v", err)
+	}
+	klog.Infof("Running Monitor.From (%d, %d]", start, fromCP.Size)
+	var resErr error
+	for i := start; i < fromCP.Size; i++ {
+		klog.V(1).Infof("Leaf index %d: fetching leaf", i)
+		rawLeaf, err := client.GetLeaf(ctx, m.st.Fetcher, i)
+		if err != nil {
+			return fmt.Errorf("failed to get leaf at index %d: %v", i, err)
+		}
+		klog.V(1).Infof("Leaf index %d: fetching and verifying inclusion proof", i)
+		hash := m.st.Hasher.HashLeaf(rawLeaf)
+		ip, err := pb.InclusionProof(ctx, i)
+		if err != nil {
+			return fmt.Errorf("failed to get inclusion proof for index %d: %v", i, err)
+		}
+
+		if err := proof.VerifyInclusion(m.st.Hasher, i, fromCP.Size, hash, ip, fromCP.Hash); err != nil {
+			return fmt.Errorf("VerifyInclusionProof() %d: %v", i, err)
+		}
+
+		klog.V(1).Infof("Leaf index %d: parsing", i)
+		releaseNote, err := note.Open([]byte(rawLeaf), m.sigStore.allV)
+		if err != nil {
+			if e, ok := err.(*note.UnverifiedNoteError); ok && len(e.Note.UnverifiedSigs) > 0 {
+				return fmt.Errorf("unknown signer %q for leaf at index %d: %v", e.Note.UnverifiedSigs[0].Name, i, err)
+			}
+			return fmt.Errorf("failed to open leaf note at index %d: %v", i, err)
+		}
+
+		var release ftlog.FirmwareRelease
+		if err := json.Unmarshal([]byte(releaseNote.Text), &release); err != nil {
+			return fmt.Errorf("failed to unmarshal release at index %d: %w", i, err)
+		}
+
+		assertSigners := func(n *note.Note, names ...note.Verifier) error {
+			needed := make(map[string]bool)
+			for _, n := range names {
+				needed[n.Name()] = true
+			}
+			for _, s := range n.Sigs {
+				if !needed[s.Name] {
+					return fmt.Errorf("unexpected sig for %s", s.Name)
+				}
+				delete(needed, s.Name)
+			}
+			if len(needed) > 0 {
+				keys := make([]string, 0, len(needed))
+				for k := range needed {
+					keys = append(keys, k)
+				}
+				return fmt.Errorf("no sigs found for %v", keys)
+			}
+			return nil
+		}
+		switch release.Component {
+		case ftlog.ComponentApplet:
+			if err := assertSigners(releaseNote, m.sigStore.appV); err != nil {
+				return fmt.Errorf("applet sig verification failed: %v", err)
+			}
+		case ftlog.ComponentOS:
+			if err := assertSigners(releaseNote, m.sigStore.osV1, m.sigStore.osV2); err != nil {
+				return fmt.Errorf("os sig verification failed: %v", err)
+			}
+		default:
+			// TODO(mhutchinson): support boot and recovery
+			return fmt.Errorf("Unsupported component: %q", release.Component)
+		}
+
+		klog.V(1).Infof("Leaf index %d: verifying manifest: %s@%s (%s)", i, release.Component, release.GitTagName, release.GitCommitFingerprint)
+		if err := m.handler(ctx, i, release); err != nil {
+			resErr = err
+			klog.Errorf("Error verifying index %d: %v", i, err)
+		}
+	}
+	if resErr != nil {
+		return resErr
+	}
+	return os.WriteFile(m.stateFile, m.st.LatestConsistentRaw, 0644)
+}
+
+// stateTrackerFromFlags constructs a state tracker based on the flags provided to the main invocation.
+// The checkpoint returned will be the checkpoint representing this monitor's view of the log history.
+// A boolean is returned that is true if the checkpoint was fetched from the log to initialize state.
+func stateTrackerFromFlags(ctx context.Context) (client.LogStateTracker, bool, error) {
+	if len(*stateFile) == 0 {
+		return client.LogStateTracker{}, false, errors.New("--state_file required")
+	}
+
+	state, err := os.ReadFile(*stateFile)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return client.LogStateTracker{}, false, fmt.Errorf("could not read state file %q: %w", *stateFile, err)
+		}
+		klog.Infof("State file %q missing. Will trust first checkpoint received from log.", *stateFile)
+	}
+
+	root, err := url.Parse(*logURL)
+	if err != nil {
+		return client.LogStateTracker{}, false, fmt.Errorf("failed to parse log URL %q: %w", *logURL, err)
+	}
+	f, err := newFetcher(root)
+	if err != nil {
+		return client.LogStateTracker{}, false, fmt.Errorf("failed to create fetcher: %v", err)
+	}
+
+	lSigV, err := note.NewVerifier(*logPubKey)
+	if err != nil {
+		return client.LogStateTracker{}, false, fmt.Errorf("unable to create new log signature verifier: %w", err)
+	}
+
+	lst, err := client.NewLogStateTracker(ctx, f, rfc6962.DefaultHasher, state, lSigV, *logOrigin, client.UnilateralConsensus(f))
+	return lst, state == nil, err
+}
+
+// newFetcher creates a Fetcher for the log at the given root location.
+func newFetcher(root *url.URL) (client.Fetcher, error) {
+	if s := root.Scheme; s != "http" && s != "https" {
+		return nil, fmt.Errorf("unsupported URL scheme %s", s)
+	}
+
+	return func(ctx context.Context, p string) ([]byte, error) {
+		u, err := root.Parse(p)
+		if err != nil {
+			return nil, err
+		}
+		resp, err := http.Get(u.String())
+		if err != nil {
+			return nil, err
+		}
+		defer resp.Body.Close()
+		return io.ReadAll(resp.Body)
+	}, nil
+}

--- a/verifier/build/main.go
+++ b/verifier/build/main.go
@@ -324,7 +324,14 @@ func newFetcher(root *url.URL) (client.Fetcher, error) {
 			return nil, err
 		}
 		defer resp.Body.Close()
-		return io.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, err
+		}
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("got non-OK status code (%d) from %s", resp.StatusCode, u)
+		}
+		return body, nil
 	}, nil
 }
 

--- a/verifier/build/main.go
+++ b/verifier/build/main.go
@@ -95,7 +95,7 @@ func main() {
 		}
 	}
 
-	klog.Info("No known backlog, switching mode to poll log for new checkpoints...")
+	klog.Infof("No known backlog, switching mode to poll log for new checkpoints. Current size: %d", st.LatestConsistent.Size)
 
 	// We've processed all leaves committed to by the tracker's checkpoint, and now we enter polling mode.
 	ticker := time.NewTicker(*pollInterval)

--- a/verifier/build/verify.go
+++ b/verifier/build/verify.go
@@ -1,0 +1,191 @@
+// Copyright 2023 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/transparency-dev/armored-witness-common/release/firmware/ftlog"
+	"k8s.io/klog/v2"
+)
+
+const (
+	gitOwner      = "transparency-dev"
+	gitRepoApplet = "armored-witness-applet"
+	gitRepoOS     = "armored-witness-os"
+)
+
+// NewReproducibleBuildVerifier returns a ReproducibleBuildVerifier that will delete
+// any temporary git repositories after use if cleanup is true, or leave them around
+// for further investigation if false.
+func NewReproducibleBuildVerifier(cleanup bool, tamago Tamago, sigs releaseSigStore) (*ReproducibleBuildVerifier, error) {
+	return &ReproducibleBuildVerifier{
+		cleanup: cleanup,
+		tamago:  tamago,
+		sigs:    sigs,
+	}, nil
+}
+
+// ReproducibleBuildVerifier checks out the source code referenced by a manifest and
+// determines whether it can reproduce the final build artifacts.
+type ReproducibleBuildVerifier struct {
+	cleanup bool
+	tamago  Tamago
+	sigs    releaseSigStore
+}
+
+// VerifyManifest attempts to reproduce the FirmwareRelease at index `i` in the log by
+// checking out the code and running the make file.
+func (v *ReproducibleBuildVerifier) VerifyManifest(ctx context.Context, i uint64, r ftlog.FirmwareRelease) error {
+	klog.V(1).Infof("VerifyManifest %d: %s@%s", i, r.Component, r.GitTagName)
+	var cv componentVerifier
+	switch r.Component {
+	case ftlog.ComponentApplet:
+		cv = appletVerifier{}
+	case ftlog.ComponentOS:
+		cv = osVerifier{}
+	default:
+		return fmt.Errorf("Unsupported component: %q", r.Component)
+	}
+
+	// Download, install, and then set up tamago environment to match manifest
+	if err := v.tamago.Switch(r.TamagoVersion); err != nil {
+		return fmt.Errorf("failed to switch tamago version: %v", err)
+	}
+
+	// Create temporary directory that will be cleaned up after this method returns
+	dir, err := os.MkdirTemp("", "armored-witness-build-verify")
+	if err != nil {
+		return fmt.Errorf("failed to create temp directory: %v", err)
+	}
+	if v.cleanup {
+		defer os.RemoveAll(dir)
+	} else {
+		klog.Infof("Cleanup disabled: %q will not be deleted after use", dir)
+	}
+
+	klog.V(1).Infof("Cloning repo into %q", dir)
+
+	// Clone the repository at the release tag
+	// TODO(mhutchinson): this should check out the GitTagName but we don't tag
+	// all releases in CI.
+	// 	cmd := exec.Command("/usr/bin/git", "clone", fmt.Sprintf("https://github.com/%s/%s", gitOwner, repo), "-b", r.GitTagName)
+	repo := cv.repo()
+	cmd := exec.Command("/usr/bin/git", "clone", cv.repo())
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to clone: %v (%s)", err, out)
+	}
+
+	repoRoot := filepath.Join(dir, repo[strings.LastIndex(repo, "/"):])
+
+	cmd = exec.Command("/usr/bin/git", "reset", "--hard", r.GitCommitFingerprint)
+	cmd.Dir = repoRoot
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to reset to commit: %v (%s)", err, out)
+	}
+
+	// Confirm that the git revision matches the manifest
+	// This has been left in with the expectation that we check out by TagName above
+	// at some point. If we don't do that then this is pretty redundant.
+	cmd = exec.Command("/usr/bin/git", "rev-parse", "HEAD")
+	cmd.Dir = repoRoot
+	out, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("failed to get HEAD revision: %v (%s)", err, out)
+	}
+	if got, want := strings.TrimSpace(string(out)), r.GitCommitFingerprint; got != want {
+		return fmt.Errorf("expected revision %q but got %q for tag %q", want, got, r.GitTagName)
+	}
+
+	// Make the elf file
+	cmd = cv.makeCommand()
+	cmd.Dir = repoRoot
+	cmd.Env = append(cmd.Env, v.tamago.Envs(r.TamagoVersion)...)
+	cmd.Env = append(cmd.Env, v.sigs.envs...)
+	cmd.Env = append(cmd.Env, fmt.Sprintf("GIT_SEMVER_TAG=%s", r.GitTagName))
+	klog.V(1).Infof("Running %q in %s", cmd.String(), repoRoot)
+	if klog.V(2).Enabled() {
+		for _, e := range cmd.Env {
+			klog.V(2).Infof("  %s", e)
+		}
+	}
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to make: %v (%s)", err, out)
+	} else if klog.V(2).Enabled() {
+		klog.V(2).Info(string(out))
+	}
+
+	// Hash the firmware artifact.
+	data, err := os.ReadFile(filepath.Join(repoRoot, cv.binFile()))
+	if err != nil {
+		return fmt.Errorf("failed to read %s: %v", cv.binFile(), err)
+	}
+	if got, want := sha256.Sum256(data), r.FirmwareDigestSha256; !bytes.Equal(got[:], want) {
+		// TODO: report this in a more visible way than an error in the log.
+		klog.Errorf("Leaf index %d: ❌ failed to reproduce build %s@%s (%s) => (got %x, wanted %x)", i, r.Component, r.GitTagName, r.GitCommitFingerprint, got, want)
+		return nil
+	}
+
+	klog.Infof("Leaf index %d: ✅ reproduced build %s@%s (%s) => %x", i, r.Component, r.GitTagName, r.GitCommitFingerprint, r.FirmwareDigestSha256)
+	return nil
+}
+
+type componentVerifier interface {
+	repo() string
+	makeCommand() *exec.Cmd
+	binFile() string
+}
+type appletVerifier struct {
+}
+
+func (v appletVerifier) repo() string {
+	return fmt.Sprintf("https://github.com/%s/%s", gitOwner, gitRepoApplet)
+}
+
+func (v appletVerifier) makeCommand() *exec.Cmd {
+	cmd := exec.Command("/usr/bin/make", "trusted_applet_nosign")
+	// cmd.Env = append(cmd.Env, "DEBUG=1")
+	// cmd.Env = append(cmd.Env, "BEE=1")
+	return cmd
+}
+
+func (v appletVerifier) binFile() string {
+	return "bin/trusted_applet.elf"
+}
+
+type osVerifier struct {
+}
+
+func (v osVerifier) repo() string {
+	return fmt.Sprintf("https://github.com/%s/%s", gitOwner, gitRepoOS)
+}
+
+func (v osVerifier) makeCommand() *exec.Cmd {
+	cmd := exec.Command("/usr/bin/make", "trusted_os_release")
+	// cmd.Env = append(cmd.Env, "DEBUG=1")
+	// cmd.Env = append(cmd.Env, "BEE=1")
+	return cmd
+}
+
+func (v osVerifier) binFile() string {
+	return "bin/trusted_os.elf"
+}

--- a/verifier/build/verify.go
+++ b/verifier/build/verify.go
@@ -36,7 +36,7 @@ const (
 // NewReproducibleBuildVerifier returns a ReproducibleBuildVerifier that will delete
 // any temporary git repositories after use if cleanup is true, or leave them around
 // for further investigation if false.
-func NewReproducibleBuildVerifier(cleanup bool, tamago Tamago, sigs releaseSigStore) (*ReproducibleBuildVerifier, error) {
+func NewReproducibleBuildVerifier(cleanup bool, tamago Tamago, sigs releaseImplicitMetadata) (*ReproducibleBuildVerifier, error) {
 	return &ReproducibleBuildVerifier{
 		cleanup: cleanup,
 		tamago:  tamago,
@@ -49,7 +49,7 @@ func NewReproducibleBuildVerifier(cleanup bool, tamago Tamago, sigs releaseSigSt
 type ReproducibleBuildVerifier struct {
 	cleanup bool
 	tamago  Tamago
-	sigs    releaseSigStore
+	sigs    releaseImplicitMetadata
 }
 
 // VerifyManifest attempts to reproduce the FirmwareRelease at index `i` in the log by


### PR DESCRIPTION
This follows the log, extracting each manifest file, and for each:
 - downloads and installs the required tamago versions at runtime
 - checks out the code from the repo
 - build it using the Makefile
 - checks that the artifact hash matches

Sample output:
```
docker run armored-witness-build-verifier -start_index=26
I1214 12:51:24.348703       1 main.go:306] State file "/tmp/state" missing. Will trust first checkpoint received from log.
I1214 12:51:24.489781       1 main.go:91] No previous checkpoint, starting at 26
I1214 12:51:24.512174       1 main.go:214] Running Monitor.From (26, 33]
I1214 12:51:24.660307       1 installer.go:69] Downloading and installing tamago 1.21.3
I1214 12:51:34.295209       1 installer.go:92] Installed tamago 1.21.3 at /usr/local/tamago-go/1.21.3
E1214 12:51:57.769589       1 verify.go:144] Leaf index 26: ❌ failed to reproduce build TRUSTED_OS@0.2.1702490857-incompatible (492add38592d6bd63aa88d41e9398e8a74ed5809) => (got b23fe4d5cab64f50927a35747ba87c7247e82a6d244b516b77c3f5caa87531a0, wanted be6ede6ff4db63c9a62c9c99c99bc9e307b27379c38289182030817e4a4bd681)
E1214 12:52:03.825937       1 verify.go:144] Leaf index 27: ❌ failed to reproduce build TRUSTED_APPLET@0.2.1702491522-incompatible (ccd6ea5409eb61fbac58a83b2d4f0de2f5fa7c2d) => (got 795e4cb4b34eca4f3426121156bc236002af8a49d72f1c4c32b8fd125416a06b, wanted ee589be667e4def945ef7e9c160494a4b07f4c3d60ed86e5074feaa3ee256209)
I1214 12:52:05.472445       1 verify.go:148] Leaf index 28: ✅ reproduced build TRUSTED_OS@0.2.1702494873-incompatible (e423602a28931e7898592064de1247004899c83e) => 529ff3dc35fac0e748dfeaf47ad7f40acdaa48a30d4d8cd6237ba781a529534b
I1214 12:52:07.132759       1 verify.go:148] Leaf index 29: ✅ reproduced build TRUSTED_APPLET@0.2.1702494914-incompatible (7b4a0d2d4e9bc2b00da711ddb8d50511cbb6bc24) => f56de99f4bdd6348a32d3a8db4e07dcc22b8b5db529226b9057295cd2bfadb9f
I1214 12:52:08.623498       1 verify.go:148] Leaf index 30: ✅ reproduced build TRUSTED_APPLET@0.2.1702496098-incompatible (90609d7dc0e193b027c79699394eedab119070ab) => 32422b8588a487158557c9f1b46b173b7d2b0f5d5139279e205df579c5a82efc
I1214 12:52:10.452363       1 verify.go:148] Leaf index 31: ✅ reproduced build TRUSTED_OS@0.2.1702496795-incompatible (0623ea61bd4517c9e2fa6ca4ed94639b11e86192) => 0017ec162fa57b62f35e413f406b8e7ffa6b9d37b3ffc26b6f08ca7b38eb3b28
I1214 12:52:12.987214       1 verify.go:148] Leaf index 32: ✅ reproduced build TRUSTED_OS@0.2.1702543912-incompatible (e8683238e0f84890f48ac1da0fea9b6f88b66b59) => 0d31953fb6a76fbe055fd0f337cd72bbe9ad0638d25079280cc9ec5fd2160c0e
I1214 12:52:12.991498       1 main.go:98] No known backlog, switching mode to poll log for new checkpoints...
```

This can provide far more output about the make file command, environment, etc if higher log verbosity is passed in via the `-v` flag.