### PR TITLE
Roll the CI log

### DIFF
--- a/deployment/api_transparency_dev/main.tf
+++ b/deployment/api_transparency_dev/main.tf
@@ -124,25 +124,25 @@ resource "google_compute_url_map" "default" {
     # CI log & aretefacts rules
     path_rule {
       paths = [
-        "/armored-witness-firmware/ci/log/0/*"
+        "/armored-witness-firmware/ci/log/1/*"
       ]
       route_action {
         url_rewrite {
           path_prefix_rewrite = "/"
         }
       }
-      service = google_compute_backend_bucket.firmware_log_ci.id
+      service = google_compute_backend_bucket.firmware_log_ci_1.id
     }
     path_rule {
       paths = [
-        "/armored-witness-firmware/ci/artefacts/0/*"
+        "/armored-witness-firmware/ci/artefacts/1/*"
       ]
       route_action {
         url_rewrite {
           path_prefix_rewrite = "/"
         }
       }
-      service = google_compute_backend_bucket.firmware_artefacts_ci.id
+      service = google_compute_backend_bucket.firmware_artefacts_ci_1.id
     }
 
     # TODO(prod logs & artefacts)
@@ -150,17 +150,17 @@ resource "google_compute_url_map" "default" {
 }
 
 # Corresponding load balancer backend buckets.
-resource "google_compute_backend_bucket" "firmware_log_ci" {
-  name        = "firmware-log-ci-backend"
-  description = "Contains CI firmware transparency log"
-  bucket_name = "armored-witness-firmware-log-ci" # google_storage_bucket.armored_witness_firmware_log_ci.name
+resource "google_compute_backend_bucket" "firmware_log_ci_1" {
+  name        = "firmware-log-ci-backend-1"
+  description = "Contains CI firmware transparency log 1"
+  bucket_name = "armored-witness-firmware-log-ci-1" # google_storage_bucket.armored_witness_firmware_log_ci.name
   enable_cdn  = false
 }
 
-resource "google_compute_backend_bucket" "firmware_artefacts_ci" {
-  name        = "firmware-artefacts-ci-backend"
-  description = "Contains CI firmware artefacts"
-  bucket_name = "armored-witness-firmware-ci" # google_storage_bucket.armored_witness_firmware_ci.name
+resource "google_compute_backend_bucket" "firmware_artefacts_ci_1" {
+  name        = "firmware-artefacts-ci-backend-1"
+  description = "Contains CI firmware artefacts for FT log 1"
+  bucket_name = "armored-witness-firmware-ci-1" # google_storage_bucket.armored_witness_firmware_ci.name
   enable_cdn  = false
 }
 

--- a/deployment/api_transparency_dev/main.tf
+++ b/deployment/api_transparency_dev/main.tf
@@ -218,26 +218,28 @@ resource "google_compute_global_network_endpoint" "distributor" {
   fqdn                          = var.distributor_host
 }
 
-resource "google_kms_key_ring" "terraform_state" {
-  name     = "armored-witness-bucket-tfstate"
-  location = var.tf_state_location
-}
-
-resource "google_kms_crypto_key" "terraform_state_bucket" {
-  name     = "terraform-state-bucket"
-  key_ring = google_kms_key_ring.terraform_state.id
-}
-
-resource "google_storage_bucket" "terraform_state" {
-  name          = "armored-witness-bucket-tfstate"
-  force_destroy = false
-  location      = var.tf_state_location
-  storage_class = "STANDARD"
-  versioning {
-    enabled = true
-  }
-  encryption {
-    default_kms_key_name = google_kms_crypto_key.terraform_state_bucket.id
-  }
-  uniform_bucket_level_access = true
-}
+## Terraform keys
+## Commented out here as they're provided in the build_and_release unit.
+#resource "google_kms_key_ring" "terraform_state" {
+#  name     = "armored-witness-bucket-tfstate"
+#  location = var.tf_state_location
+#}
+#
+#resource "google_kms_crypto_key" "terraform_state_bucket" {
+#  name     = "terraform-state-bucket"
+#  key_ring = google_kms_key_ring.terraform_state.id
+#}
+#
+#resource "google_storage_bucket" "terraform_state" {
+#  name          = "armored-witness-bucket-tfstate"
+#  force_destroy = false
+#  location      = var.tf_state_location
+#  storage_class = "STANDARD"
+#  versioning {
+#    enabled = true
+#  }
+#  encryption {
+#    default_kms_key_name = google_kms_crypto_key.terraform_state_bucket.id
+#  }
+#  uniform_bucket_level_access = true
+#}

--- a/deployment/api_transparency_dev/main.tf
+++ b/deployment/api_transparency_dev/main.tf
@@ -121,7 +121,32 @@ resource "google_compute_url_map" "default" {
     }
 
     #####
-    # CI log & aretefacts rules
+    ## CI log & aretefacts rules
+    # CI log rev 0
+    path_rule {
+      paths = [
+        "/armored-witness-firmware/ci/log/0/*"
+      ]
+      route_action {
+        url_rewrite {
+          path_prefix_rewrite = "/"
+        }
+      }
+      service = google_compute_backend_bucket.firmware_log_ci.id
+    }
+    path_rule {
+      paths = [
+        "/armored-witness-firmware/ci/artefacts/0/*"
+      ]
+      route_action {
+        url_rewrite {
+          path_prefix_rewrite = "/"
+        }
+      }
+      service = google_compute_backend_bucket.firmware_artefacts_ci.id
+    }
+
+    # CI log rev 1
     path_rule {
       paths = [
         "/armored-witness-firmware/ci/log/1/*"
@@ -149,20 +174,35 @@ resource "google_compute_url_map" "default" {
   }
 }
 
-# Corresponding load balancer backend buckets.
-resource "google_compute_backend_bucket" "firmware_log_ci_1" {
-  name        = "firmware-log-ci-backend-1"
-  description = "Contains CI firmware transparency log 1"
-  bucket_name = "armored-witness-firmware-log-ci-1" # google_storage_bucket.armored_witness_firmware_log_ci.name
+## Corresponding load balancer backend buckets.
+# CI log rev 0
+resource "google_compute_backend_bucket" "firmware_log_ci" {
+  name        = "firmware-log-ci-backend"
+  description = "Contains CI firmware transparency log"
+  bucket_name = "armored-witness-firmware-log-ci" # google_storage_bucket.armored_witness_firmware_log_ci.name
+  enable_cdn  = false
+}
+resource "google_compute_backend_bucket" "firmware_artefacts_ci" {
+  name        = "firmware-artefacts-ci-backend"
+  description = "Contains CI firmware artefacts for FT log"
+  bucket_name = "armored-witness-firmware-ci" # google_storage_bucket.armored_witness_firmware_ci.name
   enable_cdn  = false
 }
 
+# CI log rev 1
+resource "google_compute_backend_bucket" "firmware_log_ci_1" {
+  name        = "firmware-log-ci-backend-1"
+  description = "Contains CI firmware transparency log 1"
+  bucket_name = "armored-witness-firmware-log-ci-1" # google_storage_bucket.armored_witness_firmware_log_ci_1.name
+  enable_cdn  = false
+}
 resource "google_compute_backend_bucket" "firmware_artefacts_ci_1" {
   name        = "firmware-artefacts-ci-backend-1"
   description = "Contains CI firmware artefacts for FT log 1"
-  bucket_name = "armored-witness-firmware-ci-1" # google_storage_bucket.armored_witness_firmware_ci.name
+  bucket_name = "armored-witness-firmware-ci-1" # google_storage_bucket.armored_witness_firmware_ci_1.name
   enable_cdn  = false
 }
+
 
 resource "google_compute_global_network_endpoint_group" "distributor" {
   name                  = "distributor"

--- a/deployment/build_and_release/main.tf
+++ b/deployment/build_and_release/main.tf
@@ -95,105 +95,105 @@ resource "google_kms_key_ring" "firmware_release_prod" {
 # TODO(jayhou): This configuration cannot be applied right now because of the
 # algorithm. Uncomment again when it is supported.
 ### KMS keys
-resource "google_kms_crypto_key" "bootloader_ci" {
-  key_ring = "projects/armored-witness/locations/global/keyRings/firmware-release-ci"
-  name     = "bootloader-ci"
-  purpose  = "ASYMMETRIC_SIGN"
-  version_template {
-    algorithm        = "EC_SIGN_ED25519"
-    protection_level = "SOFTWARE"
-  }
-}
-resource "google_kms_crypto_key" "recovery_ci" {
-  key_ring = "projects/armored-witness/locations/global/keyRings/firmware-release-ci"
-  name     = "recovery-ci"
-  purpose  = "ASYMMETRIC_SIGN"
-  version_template {
-    algorithm        = "EC_SIGN_ED25519"
-    protection_level = "SOFTWARE"
-  }
-}
-resource "google_kms_crypto_key" "trusted_applet_ci" {
-  key_ring = "projects/armored-witness/locations/global/keyRings/firmware-release-ci"
-  name     = "trusted-applet-ci"
-  purpose  = "ASYMMETRIC_SIGN"
-  version_template {
-    algorithm        = "EC_SIGN_ED25519"
-    protection_level = "SOFTWARE"
-  }
-}
-resource "google_kms_crypto_key" "trusted_os_1_ci" {
-  key_ring = "projects/armored-witness/locations/global/keyRings/firmware-release-ci"
-  name     = "trusted-os-1-ci"
-  purpose  = "ASYMMETRIC_SIGN"
-  version_template {
-    algorithm        = "EC_SIGN_ED25519"
-    protection_level = "SOFTWARE"
-  }
-}
-resource "google_kms_crypto_key" "trusted_os_2_ci" {
-  key_ring = "projects/armored-witness/locations/global/keyRings/firmware-release-ci"
-  name     = "trusted-os-2-ci"
-  purpose  = "ASYMMETRIC_SIGN"
-  version_template {
-    algorithm        = "EC_SIGN_ED25519"
-    protection_level = "SOFTWARE"
-  }
-}
-resource "google_kms_crypto_key" "ft_log_ci" {
-  key_ring = "projects/armored-witness/locations/global/keyRings/firmware-release-ci"
-  name     = "ft-log-ci"
-  purpose  = "ASYMMETRIC_SIGN"
-  version_template {
-    algorithm        = "EC_SIGN_ED25519"
-    protection_level = "SOFTWARE"
-  }
-}
-resource "google_kms_crypto_key" "bootloader_prod" {
-  key_ring = "projects/armored-witness/locations/global/keyRings/firmware-release-prod"
-  name     = "bootloader-prod"
-  purpose  = "ASYMMETRIC_SIGN"
-  version_template {
-    algorithm        = "EC_SIGN_ED25519"
-    protection_level = "SOFTWARE"
-  }
-}
-resource "google_kms_crypto_key" "recovery_prod" {
-  key_ring = "projects/armored-witness/locations/global/keyRings/firmware-release-prod"
-  name     = "recovery-prod"
-  purpose  = "ASYMMETRIC_SIGN"
-  version_template {
-    algorithm        = "EC_SIGN_ED25519"
-    protection_level = "SOFTWARE"
-  }
-}
-resource "google_kms_crypto_key" "trusted_applet_prod" {
-  key_ring = "projects/armored-witness/locations/global/keyRings/firmware-release-prod"
-  name     = "trusted-applet-prod"
-  purpose  = "ASYMMETRIC_SIGN"
-  version_template {
-    algorithm        = "EC_SIGN_ED25519"
-    protection_level = "SOFTWARE"
-  }
-}
-resource "google_kms_crypto_key" "trusted_os_prod" {
-  key_ring = "projects/armored-witness/locations/global/keyRings/firmware-release-prod"
-  name     = "trusted-os-prod"
-  purpose  = "ASYMMETRIC_SIGN"
-  version_template {
-    algorithm        = "EC_SIGN_ED25519"
-    protection_level = "SOFTWARE"
-  }
-}
-resource "google_kms_crypto_key" "ft_log_prod" {
-  key_ring = "projects/armored-witness/locations/global/keyRings/firmware-release-prod"
-  name     = "ft-log-prod"
-  purpose  = "ASYMMETRIC_SIGN"
-  version_template {
-    algorithm        = "EC_SIGN_ED25519"
-    protection_level = "SOFTWARE"
-  }
-}
+#resource "google_kms_crypto_key" "bootloader_ci" {
+#  key_ring = "projects/armored-witness/locations/global/keyRings/firmware-release-ci"
+#  name     = "bootloader-ci"
+#  purpose  = "ASYMMETRIC_SIGN"
+#  version_template {
+#    algorithm        = "EC_SIGN_ED25519"
+#    protection_level = "SOFTWARE"
+#  }
+#}
+#resource "google_kms_crypto_key" "recovery_ci" {
+#  key_ring = "projects/armored-witness/locations/global/keyRings/firmware-release-ci"
+#  name     = "recovery-ci"
+#  purpose  = "ASYMMETRIC_SIGN"
+#  version_template {
+#    algorithm        = "EC_SIGN_ED25519"
+#    protection_level = "SOFTWARE"
+#  }
+#}
+#resource "google_kms_crypto_key" "trusted_applet_ci" {
+#  key_ring = "projects/armored-witness/locations/global/keyRings/firmware-release-ci"
+#  name     = "trusted-applet-ci"
+#  purpose  = "ASYMMETRIC_SIGN"
+#  version_template {
+#    algorithm        = "EC_SIGN_ED25519"
+#    protection_level = "SOFTWARE"
+#  }
+#}
+#resource "google_kms_crypto_key" "trusted_os_1_ci" {
+#  key_ring = "projects/armored-witness/locations/global/keyRings/firmware-release-ci"
+#  name     = "trusted-os-1-ci"
+#  purpose  = "ASYMMETRIC_SIGN"
+#  version_template {
+#    algorithm        = "EC_SIGN_ED25519"
+#    protection_level = "SOFTWARE"
+#  }
+#}
+#resource "google_kms_crypto_key" "trusted_os_2_ci" {
+#  key_ring = "projects/armored-witness/locations/global/keyRings/firmware-release-ci"
+#  name     = "trusted-os-2-ci"
+#  purpose  = "ASYMMETRIC_SIGN"
+#  version_template {
+#    algorithm        = "EC_SIGN_ED25519"
+#    protection_level = "SOFTWARE"
+#  }
+#}
+#resource "google_kms_crypto_key" "ft_log_ci" {
+#  key_ring = "projects/armored-witness/locations/global/keyRings/firmware-release-ci"
+#  name     = "ft-log-ci"
+#  purpose  = "ASYMMETRIC_SIGN"
+#  version_template {
+#    algorithm        = "EC_SIGN_ED25519"
+#    protection_level = "SOFTWARE"
+#  }
+#}
+#resource "google_kms_crypto_key" "bootloader_prod" {
+#  key_ring = "projects/armored-witness/locations/global/keyRings/firmware-release-prod"
+#  name     = "bootloader-prod"
+#  purpose  = "ASYMMETRIC_SIGN"
+#  version_template {
+#    algorithm        = "EC_SIGN_ED25519"
+#    protection_level = "SOFTWARE"
+#  }
+#}
+#resource "google_kms_crypto_key" "recovery_prod" {
+#  key_ring = "projects/armored-witness/locations/global/keyRings/firmware-release-prod"
+#  name     = "recovery-prod"
+#  purpose  = "ASYMMETRIC_SIGN"
+#  version_template {
+#    algorithm        = "EC_SIGN_ED25519"
+#    protection_level = "SOFTWARE"
+#  }
+#}
+#resource "google_kms_crypto_key" "trusted_applet_prod" {
+#  key_ring = "projects/armored-witness/locations/global/keyRings/firmware-release-prod"
+#  name     = "trusted-applet-prod"
+#  purpose  = "ASYMMETRIC_SIGN"
+#  version_template {
+#    algorithm        = "EC_SIGN_ED25519"
+#    protection_level = "SOFTWARE"
+#  }
+#}
+#resource "google_kms_crypto_key" "trusted_os_prod" {
+#  key_ring = "projects/armored-witness/locations/global/keyRings/firmware-release-prod"
+#  name     = "trusted-os-prod"
+#  purpose  = "ASYMMETRIC_SIGN"
+#  version_template {
+#    algorithm        = "EC_SIGN_ED25519"
+#    protection_level = "SOFTWARE"
+#  }
+#}
+#resource "google_kms_crypto_key" "ft_log_prod" {
+#  key_ring = "projects/armored-witness/locations/global/keyRings/firmware-release-prod"
+#  name     = "ft-log-prod"
+#  purpose  = "ASYMMETRIC_SIGN"
+#  version_template {
+#    algorithm        = "EC_SIGN_ED25519"
+#    protection_level = "SOFTWARE"
+#  }
+#}
 
 resource "google_kms_key_ring" "terraform_state" {
   name     = "armored-witness-bucket-tfstate"

--- a/deployment/build_and_release/main.tf
+++ b/deployment/build_and_release/main.tf
@@ -59,25 +59,25 @@ resource "google_project_service" "storage_googleapis_com" {
 # GCS buckets
 resource "google_storage_bucket" "armored_witness_firmware" {
   location                    = "EU"
-  name                        = "armored-witness-firmware"
+  name                        = "armored-witness-firmware-1"
   storage_class               = "STANDARD"
   uniform_bucket_level_access = true
 }
-resource "google_storage_bucket" "armored_witness_firmware_ci" {
+resource "google_storage_bucket" "armored_witness_firmware_ci_1" {
   location                    = "EU"
-  name                        = "armored-witness-firmware-ci"
+  name                        = "armored-witness-firmware-ci-1"
   storage_class               = "STANDARD"
   uniform_bucket_level_access = true
 }
-resource "google_storage_bucket" "armored_witness_firmware_log" {
+resource "google_storage_bucket" "armored_witness_firmware_log_1" {
   location                    = "US"
-  name                        = "armored-witness-firmware-log"
+  name                        = "armored-witness-firmware-log-1"
   storage_class               = "STANDARD"
   uniform_bucket_level_access = true
 }
-resource "google_storage_bucket" "armored_witness_firmware_log_ci" {
+resource "google_storage_bucket" "armored_witness_firmware_log_ci_1" {
   location                    = "US"
-  name                        = "armored-witness-firmware-log-ci"
+  name                        = "armored-witness-firmware-log-ci-1"
   storage_class               = "STANDARD"
   uniform_bucket_level_access = true
 }

--- a/deployment/build_and_release/main.tf
+++ b/deployment/build_and_release/main.tf
@@ -57,21 +57,53 @@ resource "google_project_service" "storage_googleapis_com" {
 }
 
 # GCS buckets
+
+# prod log rev 0
 resource "google_storage_bucket" "armored_witness_firmware" {
   location                    = "EU"
-  name                        = "armored-witness-firmware-1"
+  name                        = "armored-witness-firmware"
   storage_class               = "STANDARD"
   uniform_bucket_level_access = true
 }
-resource "google_storage_bucket" "armored_witness_firmware_ci_1" {
+resource "google_storage_bucket" "armored_witness_firmware_log" {
+  location                    = "US"
+  name                        = "armored-witness-firmware-log"
+  storage_class               = "STANDARD"
+  uniform_bucket_level_access = true
+}
+
+# prod log rev 1
+resource "google_storage_bucket" "armored_witness_firmware_1" {
   location                    = "EU"
-  name                        = "armored-witness-firmware-ci-1"
+  name                        = "armored-witness-firmware-1"
   storage_class               = "STANDARD"
   uniform_bucket_level_access = true
 }
 resource "google_storage_bucket" "armored_witness_firmware_log_1" {
   location                    = "US"
   name                        = "armored-witness-firmware-log-1"
+  storage_class               = "STANDARD"
+  uniform_bucket_level_access = true
+}
+
+# CI log rev 0
+resource "google_storage_bucket" "armored_witness_firmware_ci" {
+  location                    = "EU"
+  name                        = "armored-witness-firmware-ci"
+  storage_class               = "STANDARD"
+  uniform_bucket_level_access = true
+}
+resource "google_storage_bucket" "armored_witness_firmware_log_ci" {
+  location                    = "US"
+  name                        = "armored-witness-firmware-log-ci"
+  storage_class               = "STANDARD"
+  uniform_bucket_level_access = true
+}
+
+# CI log rev 1
+resource "google_storage_bucket" "armored_witness_firmware_ci_1" {
+  location                    = "EU"
+  name                        = "armored-witness-firmware-ci-1"
   storage_class               = "STANDARD"
   uniform_bucket_level_access = true
 }


### PR DESCRIPTION
This PR:
- creates new log GCS buckets using a numbered scheme to allow for easy future log roll overs
- maps the new buckets to .../1/ URLs.
- comments out the currently unsupported key resources to make it easier to apply.

See also:
- https://github.com/transparency-dev/armored-witness-os/pull/117
- https://github.com/transparency-dev/armored-witness-applet/pull/185