### PR TITLE
Commit terraform lock file used to last update prod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /verify
 /build
 
+.terraform/

--- a/deployment/api_transparency_dev/.terraform.lock.hcl
+++ b/deployment/api_transparency_dev/.terraform.lock.hcl
@@ -1,0 +1,62 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "5.15.0"
+  constraints = ">= 4.50.0, < 6.0.0"
+  hashes = [
+    "h1:sIh178amGT46Ad3RFjoMnNBA0ce7UWfcY6k/EJppC2s=",
+    "zh:08cf2452888e9a8a0c853f01add35f790d3db42570e5c3743c4603333c347b48",
+    "zh:26d51a5dbe201cc1cc5c31064962b1cedb3895ab34079d06aa6a9a41224cc28e",
+    "zh:4f43bf31bbd8042251407b312629bf8c60547f9defe714f644a05287549ef7fa",
+    "zh:6d439893a7c64e5f11ebce829ec54b5c39bb20704b0d9cbce0f387949c2a4ad6",
+    "zh:783c23f9c1417b3d5f2bdb44372aeb9e05168bd15cedbe22363d2b62ad38c256",
+    "zh:b83c145d2a8ac3c0d8b2961a070af89e8f927141c9dc49e58d0af16f3588e4dd",
+    "zh:b86c8418f8d9430b6eeeb8b9c90645790ef72775144407cbfccf95b10a7e0c43",
+    "zh:d1252e570643e421e11de4e660956fa11be3b96e10ffda7f5a3cd1311a6beaed",
+    "zh:e54ab9ccadd741107836f0f32255c0eab4cd4aebc78fbbe30116ed2bbab85790",
+    "zh:e5910b392e9f44665d5f677b7970fdc828daa5d08ab2de98e378e01dfdb86d59",
+    "zh:eab61c71884bbf722293b5f05995e29356c36908a588319581bc421b98a75954",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/google-beta" {
+  version     = "5.15.0"
+  constraints = ">= 4.50.0, < 6.0.0"
+  hashes = [
+    "h1:xMbzlS2xmBhuip9B6KTo5TeaonTJNOV422Lza/AsGX4=",
+    "zh:0d06bd1799cacd09ef70cdda24339d29b14aae4e8bac5ca468260003f53cf12a",
+    "zh:0e73b1efd7b358f33c46e600e5babdd4be847848f287729c0bdccdae1bc074ef",
+    "zh:199e5a82d8e6b0ba6a916f03e140b118ced55f1c02c888881aa0b6490bddc04c",
+    "zh:220f524b43d79fc728a84175872f229fe41c6dbab0845a020f3fa0f4b4115ff8",
+    "zh:6172f6db7651f95b2746afb6a120578cec77e812641ef178221f3bbb59441b73",
+    "zh:9c8c2d245d8247ca1382b4e6a6a8fd73954856e82791183c38e1e288e1e8f301",
+    "zh:ca681248642c0ae332553426ee0ff6b3fd585ac7f3705ca7d3709d5d8ccdcb78",
+    "zh:cc9cf22970bbccbba05c10c1e3c7ee4f1b8ad28e03ae948e8fbc923d0b87734f",
+    "zh:e1fd2294f36eddade50734891523de99180ffc7218fcd58fab7a140b57a6e04c",
+    "zh:efbcb10431afd466701dfe63991caa23d26184c494a06ce44d00b10a6dae7dc3",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:ff2fe28b37d88bac239b0f9ca7b41bf7923a99c4af82ae800668c3945902d68a",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.6.0"
+  constraints = ">= 2.1.0"
+  hashes = [
+    "h1:R5Ucn26riKIEijcsiOMBR3uOAjuOMfI1x7XvH4P6B1w=",
+    "zh:03360ed3ecd31e8c5dac9c95fe0858be50f3e9a0d0c654b5e504109c2159287d",
+    "zh:1c67ac51254ba2a2bb53a25e8ae7e4d076103483f55f39b426ec55e47d1fe211",
+    "zh:24a17bba7f6d679538ff51b3a2f378cedadede97af8a1db7dad4fd8d6d50f829",
+    "zh:30ffb297ffd1633175d6545d37c2217e2cef9545a6e03946e514c59c0859b77d",
+    "zh:454ce4b3dbc73e6775f2f6605d45cee6e16c3872a2e66a2c97993d6e5cbd7055",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:91df0a9fab329aff2ff4cf26797592eb7a3a90b4a0c04d64ce186654e0cc6e17",
+    "zh:aa57384b85622a9f7bfb5d4512ca88e61f22a9cea9f30febaa4c98c68ff0dc21",
+    "zh:c4a3e329ba786ffb6f2b694e1fd41d413a7010f3a53c20b432325a94fa71e839",
+    "zh:e2699bc9116447f96c53d55f2a00570f982e6f9935038c3810603572693712d0",
+    "zh:e747c0fd5d7684e5bfad8aa0ca441903f15ae7a98a737ff6aca24ba223207e2c",
+    "zh:f1ca75f417ce490368f047b63ec09fd003711ae48487fba90b4aba2ccf71920e",
+  ]
+}


### PR DESCRIPTION
This provides a more hermetic build. Different deployers using different versions of modules could lead to unexpected and potentially dangerous sloshing of production configuration.
