### PR TITLE
URL mapping for distributor in CI environment

### DIFF
--- a/deployment/api_transparency_dev/terraform.tfvars
+++ b/deployment/api_transparency_dev/terraform.tfvars
@@ -7,5 +7,10 @@ serve_domain = "api.transparency.dev"
 
 lb_name = "transparency-dev-lb"
 
-distributor_host = "distributor-service-oxxl2d5jeq-uc.a.run.app"
-distributor_port = 443
+# TODO(mhutchinson): this is the old env and should be switched to the following
+# distributor_prod_host = "distributor-service-prod-oxxl2d5jeq-uc.a.run.app"
+distributor_prod_host = "distributor-service-oxxl2d5jeq-uc.a.run.app"
+distributor_prod_port = 443
+
+distributor_ci_host = "distributor-service-ci-oxxl2d5jeq-uc.a.run.app"
+distributor_ci_port = 443

--- a/deployment/api_transparency_dev/variables.tf
+++ b/deployment/api_transparency_dev/variables.tf
@@ -20,11 +20,18 @@ variable "tls" {
   type        = bool
 }
 
-variable "distributor_host" {
-  description = "Host name serving distributor service API"
+variable "distributor_prod_host" {
+  description = "Host name serving distributor service API (prod)"
 }
-variable "distributor_port" {
-  description = "Port on distributor_host where distributor service API is served"
+variable "distributor_prod_port" {
+  description = "Port on distributor_host where distributor service API is served (prod)"
+  type        = number
+}
+variable "distributor_ci_host" {
+  description = "Host name serving distributor service API (ci)"
+}
+variable "distributor_ci_port" {
+  description = "Port on distributor_host where distributor service API is served (ci)"
   type        = number
 }
 


### PR DESCRIPTION
This is mapped at api.transpareny.dev/distributor-ci/.
All other resources should be mapped at their old location.
