### PR TITLE
Added mappings for prod logs v0 and v1

### DIFF
--- a/deployment/api_transparency_dev/main.tf
+++ b/deployment/api_transparency_dev/main.tf
@@ -204,7 +204,53 @@ resource "google_compute_url_map" "default" {
       service = google_compute_backend_bucket.firmware_artefacts_ci_1.id
     }
 
-    # TODO(prod logs & artefacts)
+    # Prod log rev 0 (wave 0 devices)
+    path_rule {
+      paths = [
+        "/armored-witness-firmware/prod/log/0/*"
+      ]
+      route_action {
+        url_rewrite {
+          path_prefix_rewrite = "/"
+        }
+      }
+      service = google_compute_backend_bucket.firmware_log_prod_0.id
+    }
+    path_rule {
+      paths = [
+        "/armored-witness-firmware/prod/artefacts/0/*"
+      ]
+      route_action {
+        url_rewrite {
+          path_prefix_rewrite = "/"
+        }
+      }
+      service = google_compute_backend_bucket.firmware_artefacts_prod_0.id
+    }
+
+    # Prod log rev 1
+    path_rule {
+      paths = [
+        "/armored-witness-firmware/prod/log/1/*"
+      ]
+      route_action {
+        url_rewrite {
+          path_prefix_rewrite = "/"
+        }
+      }
+      service = google_compute_backend_bucket.firmware_log_prod_1.id
+    }
+    path_rule {
+      paths = [
+        "/armored-witness-firmware/prod/artefacts/1/*"
+      ]
+      route_action {
+        url_rewrite {
+          path_prefix_rewrite = "/"
+        }
+      }
+      service = google_compute_backend_bucket.firmware_artefacts_prod_1.id
+    }
   }
 }
 
@@ -234,6 +280,33 @@ resource "google_compute_backend_bucket" "firmware_artefacts_ci_1" {
   name        = "firmware-artefacts-ci-backend-1"
   description = "Contains CI firmware artefacts for FT log 1"
   bucket_name = "armored-witness-firmware-ci-1" # google_storage_bucket.armored_witness_firmware_ci_1.name
+  enable_cdn  = false
+}
+
+# Prod log 0 (Q1 2024 - wave 0 devices)
+resource "google_compute_backend_bucket" "firmware_log_prod_0" {
+  name        = "firmware-log-prod-backend-0"
+  description = "Contains prod firmware transparency log 0"
+  bucket_name = "armored-witness-firmware-log"
+  enable_cdn  = false
+}
+resource "google_compute_backend_bucket" "firmware_artefacts_prod_0" {
+  name        = "firmware-artefacts-prod-backend-0"
+  description = "Contains prod firmware artefacts for FT log 0"
+  bucket_name = "armored-witness-firmware"
+  enable_cdn  = false
+}
+# Prod log 1
+resource "google_compute_backend_bucket" "firmware_log_prod_1" {
+  name        = "firmware-log-prod-backend-1"
+  description = "Contains prod firmware transparency log 1"
+  bucket_name = "armored-witness-firmware-log-1"
+  enable_cdn  = false
+}
+resource "google_compute_backend_bucket" "firmware_artefacts_prod_1" {
+  name        = "firmware-artefacts-prod-backend-1"
+  description = "Contains prod firmware artefacts for FT log 1"
+  bucket_name = "armored-witness-firmware-1"
   enable_cdn  = false
 }
 


### PR DESCRIPTION
We can disable the v1 logs if needed, but I did that first before I noticed we had a v0 log (easily missed because the bucket doesn't contain -prod- or a version). Confirmed that this works with the following:

```bash
curl https://api.transparency.dev/armored-witness-firmware/prod/log/0/checkpoint
transparency.dev/armored-witness/firmware_transparency/prod/0
0
47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=

— armored-witness-log 9XU9YVVV0Wn9DAvAgo771NOcN/5QA1YDlAjZEHyBpO0agfpT0mHiOgqI/B9RJN00fsIT1DvzVC07nsSL1OsvI76rHAk=
```
