### PR TITLE
Use new prod environment instead of old unnamed env

### DIFF
--- a/deployment/api_transparency_dev/terraform.tfvars
+++ b/deployment/api_transparency_dev/terraform.tfvars
@@ -8,8 +8,7 @@ serve_domain = "api.transparency.dev"
 lb_name = "transparency-dev-lb"
 
 # TODO(mhutchinson): this is the old env and should be switched to the following
-# distributor_prod_host = "distributor-service-prod-oxxl2d5jeq-uc.a.run.app"
-distributor_prod_host = "distributor-service-oxxl2d5jeq-uc.a.run.app"
+ distributor_prod_host = "distributor-service-prod-oxxl2d5jeq-uc.a.run.app"
 distributor_prod_port = 443
 
 distributor_ci_host = "distributor-service-ci-oxxl2d5jeq-uc.a.run.app"


### PR DESCRIPTION
The unnamed env distributor can be turned down after this
