### PR TITLE
Support for build envs from manifest

### DIFF
--- a/verifier/build/installer.go
+++ b/verifier/build/installer.go
@@ -55,6 +55,8 @@ func (t Tamago) Switch(v semver.Version) error {
 	return nil
 }
 
+// Envs returns the KEY=value environment assigmnents required to be set for this
+// version of tamago to run.
 func (t Tamago) Envs(v semver.Version) []string {
 	vDir := filepath.Join(t.dir, v.String())
 	goPath := filepath.Join(vDir, "bin", "go")


### PR DESCRIPTION
Recent builds of the OS and Applet that provide these build envs are now reproducibly built by the verifier.

This PR also adds support for the bootlaader, but this is not currently getting a matching hash despite an identical go build line. Investigation is needed.
