### PR TITLE
Change URL for CI so it can be used with minimal code changes

### DIFF
--- a/deployment/api_transparency_dev/main.tf
+++ b/deployment/api_transparency_dev/main.tf
@@ -147,7 +147,7 @@ resource "google_compute_url_map" "default" {
       ]
       route_action {
         url_rewrite {
-          path_prefix_rewrite = "/distributor/"
+          path_prefix_rewrite = "/"
           host_rewrite        = var.distributor_ci_host
         }
       }

--- a/deployment/api_transparency_dev/main.tf
+++ b/deployment/api_transparency_dev/main.tf
@@ -143,7 +143,7 @@ resource "google_compute_url_map" "default" {
     }
     path_rule {
       paths = [
-        "/distributor-ci/*"
+        "/ci/*"
       ]
       route_action {
         url_rewrite {

--- a/deployment/api_transparency_dev/main.tf
+++ b/deployment/api_transparency_dev/main.tf
@@ -143,11 +143,12 @@ resource "google_compute_url_map" "default" {
     }
     path_rule {
       paths = [
-        "/ci/*"
+	# match on /distributor/ to prevent /metrics being exposed publicly
+        "/ci/distributor/*"
       ]
       route_action {
         url_rewrite {
-          path_prefix_rewrite = "/"
+          path_prefix_rewrite = "/distributor/"
           host_rewrite        = var.distributor_ci_host
         }
       }


### PR DESCRIPTION
This is the counterpart to https://github.com/transparency-dev/armored-witness-applet/pull/225
