### PR TITLE
Tighter cleanup work for verifier

### DIFF
--- a/verifier/build/main.go
+++ b/verifier/build/main.go
@@ -55,7 +55,7 @@ var (
 	appletReleasePubKey   = flag.String("applet_release_pubkey", "transparency.dev-aw-applet-ci+3ff32e2c+AV1fgxtByjXuPjPfi0/7qTbEBlPGGCyxqr6ZlppoLOz3", "The applet release signer's public key")
 	bootReleasePubKey     = flag.String("boot_release_pubkey", "transparency.dev-aw-boot-ci+9f62b6ac+AbnipFmpRltfRiS9JCxLUcAZsbeH4noBOJXbVD3H5Eg4", "The boot release signer's public key")
 	recoveryReleasePubKey = flag.String("recovery_release_pubkey", "transparency.dev-aw-recovery-ci+cc699423+AarlJMSl0rbTMf31B5o9bqc6PHorwvF1GbwyJRXArbfg", "The recovery release signer's public key")
-	cleanup               = flag.Bool("cleanup", true, "Set to false to keep git checkouts and make artifacts around after verification")
+	cleanup               = flag.Bool("cleanup", true, "Set to false to keep git checkouts and make artifacts around after failed verification")
 	startIndex            = flag.Uint64("start_index", 0, "Used for debugging to start verifying leaves from a given index. Only used if there is no prior checkpoint available.")
 )
 


### PR DESCRIPTION
Previously this either cleaned up all builds if enabled, or left detritus everywhere if disabled. This PR changes the disabled behaviour so that it cleans up successful builds as there's no user journey that involves investigating that. When a failed build is left about, it now prints out a more identifiable message in the log that makes it easier for an investigator to find the directory in order to get the built artifacts that don't match.
