### PR TITLE
Command to verify a single manifest

### DIFF
--- a/cmd/verify_build/README.md
+++ b/cmd/verify_build/README.md
@@ -10,7 +10,7 @@ For each manifest claim that it hasn't seen before, the following steps are take
  3. The ELF file is compiled from source
  4. The hash for the ELF in the manifest is compared against the locally built version
 
-## Running
+## Running in Continuous Mode
 
 In order to control the environment in which the code will be built,
 a Dockerfile is supplied which will create a compatible environment.
@@ -18,7 +18,7 @@ a Dockerfile is supplied which will create a compatible environment.
 This image can be built and executed using the following commands
 from the root of the repository:
 
-```bash
+```shell
 docker build . -t armored-witness-build-verifier -f ./cmd/verify_build/Dockerfile
 docker run armored-witness-build-verifier
 ```
@@ -40,3 +40,21 @@ Note that in the above, the entire directory from the failed build can be obtain
  3. Copying the directory to somewhere it can be easily inspected using `docker cp $DOCKER_CONTAINER:$EVIDENCE_DIR /tmp/evidence`
 
 To find more information about failed builds (e.g. full commandline, env variables), the verbosity can be increased by passing `--v=2` to the `docker run` command.
+
+## Verifying a Single Manifest
+
+To verify a single manifest, the same Dockerfile as above can be used, but we need to override the entrypoint command.
+The `single` command takes a signed manifest note via stdin.
+
+The example below obtains a leaf entry from the log via `curl` and pipes this directly to the verifier in single mode, running inside docker.
+
+```shell
+docker build . -t armored-witness-build-verifier -f ./cmd/verify_build/Dockerfile
+curl https://api.transparency.dev/armored-witness-firmware/ci/log/1/seq/00/00/00/00/78 | docker run -i --entrypoint "/bin/verifier" armored-witness-build-verifier single
+```
+
+It is possible to run this without using Docker if you are sure you have the correct tooling installed on your machine. Example command:
+
+```shell
+curl https://api.transparency.dev/armored-witness-firmware/ci/log/1/seq/00/00/00/00/78 | go run ./cmd/verify_build single --tamago_dir=$HOME/tamago/
+```

--- a/cmd/verify_build/cmd/internal/build/installer.go
+++ b/cmd/verify_build/cmd/internal/build/installer.go
@@ -84,7 +84,7 @@ func (t Tamago) install(v semver.Version, dir string) error {
 		return err
 	}
 	// Create the directory and then extract into it
-	if err := os.Mkdir(dir, os.ModeDir); err != nil {
+	if err := os.Mkdir(dir, 0755); err != nil {
 		return err
 	}
 	if err := curl.Run(); err != nil {

--- a/cmd/verify_build/cmd/root.go
+++ b/cmd/verify_build/cmd/root.go
@@ -34,6 +34,20 @@ a verifier that checks that the binary committed to by a manifest file can be
 reproduced by building it again.`,
 }
 
+func init() {
+	rootCmd.PersistentFlags().String("log_url", "https://api.transparency.dev/armored-witness-firmware/ci/log/1/", "URL identifying the location of the log.")
+	rootCmd.PersistentFlags().String("log_origin", "transparency.dev/armored-witness/firmware_transparency/ci/1", "The expected first line of checkpoints issued by the log.")
+	rootCmd.PersistentFlags().String("log_pubkey", "transparency.dev-aw-ftlog-ci+f5479c1e+AR6gW0mycDtL17iM2uvQUThJsoiuSRirstEj9a5AdCCu", "The log's public key.")
+	rootCmd.PersistentFlags().String("os_release_pubkey1", "transparency.dev-aw-os1-ci+7a0eaef3+AcsqvmrcKIbs21H2Bm2fWb6oFWn/9MmLGNc6NLJty2eQ", "The first OS release signer's public key.")
+	rootCmd.PersistentFlags().String("os_release_pubkey2", "transparency.dev-aw-os2-ci+af8e4114+AbBJk5MgxRB+68KhGojhUdSt1ts5GAdRIT1Eq9zEkgQh", "The second OS release signer's public key.")
+	rootCmd.PersistentFlags().String("applet_release_pubkey", "transparency.dev-aw-applet-ci+3ff32e2c+AV1fgxtByjXuPjPfi0/7qTbEBlPGGCyxqr6ZlppoLOz3", "The applet release signer's public key.")
+	rootCmd.PersistentFlags().String("boot_release_pubkey", "transparency.dev-aw-boot-ci+9f62b6ac+AbnipFmpRltfRiS9JCxLUcAZsbeH4noBOJXbVD3H5Eg4", "The boot release signer's public key.")
+	rootCmd.PersistentFlags().String("recovery_release_pubkey", "transparency.dev-aw-recovery-ci+cc699423+AarlJMSl0rbTMf31B5o9bqc6PHorwvF1GbwyJRXArbfg", "The recovery release signer's public key.")
+
+	rootCmd.PersistentFlags().Bool("cleanup", true, "Set to false to keep git checkouts and make artifacts around after failed verification.")
+	rootCmd.PersistentFlags().String("tamago_dir", "/usr/local/tamago-go", "Directory in which versions of tamago should be installed to. User must have read/write permission to this directory.")
+}
+
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {

--- a/cmd/verify_build/cmd/single.go
+++ b/cmd/verify_build/cmd/single.go
@@ -1,0 +1,74 @@
+// Copyright 2024 The Armored Witness authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cmd
+
+import (
+	"context"
+	"io"
+
+	"github.com/spf13/cobra"
+	"github.com/transparency-dev/armored-witness/cmd/verify_build/cmd/internal/build"
+	"k8s.io/klog/v2"
+)
+
+// singleCmd represents the single-manifest command
+var (
+	singleCmd = &cobra.Command{
+		Use:   "single",
+		Short: "Verify a single manifest entry to check whether it can be reproducibly built",
+		Long:  "The manifest to verify should be provided on stdin.",
+		Run:   single,
+	}
+)
+
+func init() {
+	rootCmd.AddCommand(singleCmd)
+}
+
+func single(cmd *cobra.Command, args []string) {
+	ctx := context.Background()
+
+	tamago, err := build.NewTamago(requireFlagString(cmd.Flags(), "tamago_dir"))
+	if err != nil {
+		klog.Exitf("Failed to init tamago: %v", err)
+	}
+	metadata, err := build.NewReleaseImplicitMetadata(
+		requireFlagString(cmd.Flags(), "log_pubkey"),
+		requireFlagString(cmd.Flags(), "os_release_pubkey1"),
+		requireFlagString(cmd.Flags(), "os_release_pubkey2"),
+		requireFlagString(cmd.Flags(), "applet_release_pubkey"),
+		requireFlagString(cmd.Flags(), "boot_release_pubkey"),
+		requireFlagString(cmd.Flags(), "recovery_release_pubkey"))
+	if err != nil {
+		klog.Exitf("Failed to initialize metadata: %v", err)
+	}
+	defer metadata.Cleanup()
+
+	rbv, err := build.NewReproducibleBuildVerifier(requireFlagBool(cmd.Flags(), "cleanup"), tamago, metadata)
+	if err != nil {
+		klog.Exitf("Failed to create reproducible build verifier: %v", err)
+	}
+
+	nbs, err := io.ReadAll(cmd.Root().InOrStdin())
+	if err != nil {
+		klog.Exitf("Failed to read manifest from stdin: %v", err)
+	}
+	klog.V(1).Infof("Read %d bytes:\n%s", len(nbs), nbs)
+	if err := rbv.Verify(ctx, 0, nbs); err != nil {
+		klog.Exitf("Failed to verify manifest: %v", err)
+	}
+	klog.Info("Success!")
+}


### PR DESCRIPTION
This doesn't perform any of the log operations, but just checks that a manifest is signed correctly, and that the build can be reproduced from the info in the manifest.

Common flags have been moved to the root command to be inherited by all child commands.
This avoids duplication and makes it easier to see what unique flags each command defines.
