### PR TITLE
Fix provision

### DIFF
--- a/cmd/provision/main.go
+++ b/cmd/provision/main.go
@@ -360,10 +360,10 @@ func waitAndProvision(ctx context.Context, fw *firmwares) error {
 
 	srkEnv, ok := expectedSRKHashes[s.SRKHash]
 	if !ok {
-		return fmt.Errorf("witness OS reports UNKNOWN SRK Hash '%x', not fusing.", s.SRKHash)
+		return fmt.Errorf("witness OS reports UNKNOWN SRK Hash '%s', not fusing.", s.SRKHash)
 	}
 	if srkEnv != *habTarget {
-		return fmt.Errorf("witness OS reports SRK Hash (%x) for unexpected release environment %q - we're set to %q, not fusing.", s.SRKHash, srkEnv, *habTarget)
+		return fmt.Errorf("witness OS reports SRK Hash (%s) for unexpected release environment %q - we're set to %q, not fusing.", s.SRKHash, srkEnv, *habTarget)
 	}
 
 	if *fuse {

--- a/cmd/provision/main.go
+++ b/cmd/provision/main.go
@@ -360,10 +360,18 @@ func waitAndProvision(ctx context.Context, fw *firmwares) error {
 
 	srkEnv, ok := expectedSRKHashes[s.SRKHash]
 	if !ok {
-		return fmt.Errorf("witness OS reports UNKNOWN SRK Hash '%s', not fusing.", s.SRKHash)
+		e := fmt.Errorf("witness OS reports UNKNOWN SRK Hash '%s', not fusing.", s.SRKHash)
+		if *fuse {
+			return e
+		}
+		klog.Warningf("⚠️ " + e.Error())
 	}
 	if srkEnv != *habTarget {
-		return fmt.Errorf("witness OS reports SRK Hash (%s) for unexpected release environment %q - we're set to %q, not fusing.", s.SRKHash, srkEnv, *habTarget)
+		e := fmt.Errorf("witness OS reports SRK Hash (%s) for unexpected release environment %q - we're set to %q, not fusing.", s.SRKHash, srkEnv, *habTarget)
+		if *fuse {
+			return e
+		}
+		klog.Warningf("⚠️ " + e.Error())
 	}
 
 	if *fuse {


### PR DESCRIPTION
This PR fixes the printing of SRK hashes, and makes the process not hard fail on SRK related checks if we weren't going to fuse anyway.