### PR TITLE
No applet for fusing

### DIFF
--- a/cmd/provision/main.go
+++ b/cmd/provision/main.go
@@ -352,7 +352,7 @@ func waitAndProvision(ctx context.Context, fw *firmwares) error {
 		// This is ensure there's no unexpected CPU load on the device when
 		// we attempt to set fuses as this has been known to be timing sensitive.
 		flashStages = append(flashStages, firmwares{TrustedApplet: fw.TrustedApplet})
-		flashStages[0].TrustedApplet = nil
+		flashStages[0].TrustedApplet.Bundle.Firmware = []byte{}
 	}
 	if err := flashImages(bDev, &flashStages[0]); err != nil {
 		return fmt.Errorf("error while flashing images: %v", err)

--- a/cmd/provision/main.go
+++ b/cmd/provision/main.go
@@ -213,7 +213,6 @@ type firmwares struct {
 type firmwareJobs struct {
 	bootloader       flashJob
 	bootloaderConfig flashJob
-	recovery         flashJob
 	trustedOS        flashJob
 	trustedApplet    flashJob
 }

--- a/cmd/provision/main.go
+++ b/cmd/provision/main.go
@@ -468,6 +468,7 @@ func waitAndProvision(ctx context.Context, fw *firmwares) error {
 			}
 			klog.Warningf("⚠️ %s, continuing anyway", err.Error())
 		}
+		klog.Infof("%d remaining firmware(s) to install", len(flashStages[1]))
 
 		klog.Info("Operator, please change boot switch to USB, and then reboot device 🙏")
 		klog.Info("Waiting for device to boot...")

--- a/cmd/provision/main.go
+++ b/cmd/provision/main.go
@@ -462,7 +462,11 @@ func waitAndProvision(ctx context.Context, fw *firmwares) error {
 			<-time.After(time.Second)
 		}
 		if err := device.ActivateHAB(dev); err != nil {
-			return fmt.Errorf("device failed to activate HAB: %v", err)
+			err = fmt.Errorf("device failed to activate HAB: %v", err)
+			if !*runAnyway {
+				return err
+			}
+			klog.Warningf("⚠️ %s, continuing anyway", err.Error())
 		}
 
 		klog.Info("Operator, please change boot switch to USB, and then reboot device 🙏")


### PR DESCRIPTION
This PR changes the behaviour of `provision` depending on whether or not it's been asked to fuse the target device: 

   * When `provision` is run with `--fuse`, the firmware will be installed in two passes: first the bootloader and OS are installed, and the device is booted and asked fuse itself. Then, the applet is installed.

   * When `--fuse` is not set, all firmware images are installed onto the device at the same time.

The reason for the change is that the fusing operation, which is done by the device itself when it is running the armored witness firmware, is somewhat sensitive to timing, and having the Applet booting up - establishing a network stack, loading checkpoints from disk, connecting to logs and distributor, etc. - at the same time as we're asking the OS to fuse exacerbates the issue. 
