### PR TITLE
Add recovery trigger to Terraform.

### DIFF
--- a/deployment/build_and_release/live/ci/terragrunt.hcl
+++ b/deployment/build_and_release/live/ci/terragrunt.hcl
@@ -42,6 +42,8 @@ inputs = merge(
     # HAB-related
     srk_hash = "b8ba457320663bf006accd3c57e06720e63b21ce5351cb91b4650690bb08d85a"
     hab_key_version = 1
+    hab_revision = 4
+    hab_leaf_minor = "-2"
 
     # Pinned at tag [v20231018](https://github.com/usbarmory/armory-ums/releases/tag/v20231018)
     armory_ums_version: "850baf54809bd29548d6f817933240043400a4e1"

--- a/deployment/build_and_release/live/ci/terragrunt.hcl
+++ b/deployment/build_and_release/live/ci/terragrunt.hcl
@@ -38,6 +38,12 @@ inputs = merge(
     bee = "1"
     debug = "1"
     checkpoint_cache = "public, max-age=30"
+
+    # HAB-related
     srk_hash = "b8ba457320663bf006accd3c57e06720e63b21ce5351cb91b4650690bb08d85a"
+    hab_key_version = 1
+
+    # Pinned at tag [v20231018](https://github.com/usbarmory/armory-ums/releases/tag/v20231018)
+    armory_ums_version: "850baf54809bd29548d6f817933240043400a4e1"
   }
 )

--- a/deployment/build_and_release/live/prod/terragrunt.hcl
+++ b/deployment/build_and_release/live/prod/terragrunt.hcl
@@ -29,7 +29,7 @@ inputs = merge(
     firmware_bucket_prefix = "armored-witness-firmware-prod"
     origin_prefix = "transparency.dev/armored-witness/firmware_transparency/prod"
     
-    tamago_version = "1.21.5"
+    tamago_version = "1.22.0"
     entries_dir = "firmware-log-sequence"
     log_public_key = "transparency.dev-aw-ftlog-prod+72b0da75+Aa3qdhefd2cc/98jV3blslJT2L+iFR8WKHeGcgFmyjnt"
     applet_public_key = "transparency.dev-aw-applet-prod+d45f2a0d+AZSnFa8GxH+jHV6ahELk6peqVObbPKrYAdYyMjrzNF35"
@@ -38,6 +38,12 @@ inputs = merge(
     bee = "1"
     debug = "1"
     checkpoint_cache = "public, max-age=30"
+
+    # HAB-related
     srk_hash = "TODO"
+    hab_key_version = 1
+
+    # Pinned at tag [v20231018](https://github.com/usbarmory/armory-ums/releases/tag/v20231018)
+    armory_ums_version: "850baf54809bd29548d6f817933240043400a4e1"
   }
 )

--- a/deployment/build_and_release/live/prod/terragrunt.hcl
+++ b/deployment/build_and_release/live/prod/terragrunt.hcl
@@ -42,6 +42,8 @@ inputs = merge(
     # HAB-related
     srk_hash = "TODO"
     hab_key_version = 1
+    hab_revision = 0
+    hab_leaf_minor = "-0"
 
     # Pinned at tag [v20231018](https://github.com/usbarmory/armory-ums/releases/tag/v20231018)
     armory_ums_version: "850baf54809bd29548d6f817933240043400a4e1"

--- a/deployment/build_and_release/modules/release/main.tf
+++ b/deployment/build_and_release/modules/release/main.tf
@@ -463,4 +463,274 @@ resource "google_cloudbuild_trigger" "os_build" {
   }
 }
 
+resource "google_cloudbuild_trigger" "build_recovery" {
+  name = "recovery-build-${var.env}"
+  location = "global"
+
+  github {
+    owner = "transparency-dev"
+    name  = "armored-witness-boot"
+
+    push {
+      branch = var.cloudbuild_trigger_branch != "" ? var.cloudbuild_trigger_branch : null
+      tag = var.cloudbuild_trigger_tag != "" ? var.cloudbuild_trigger_tag : null
+    }
+  }
+
+  build {
+    # If the trigger is not based on `tag`, create a fake one.
+    #
+    # Unfortunately, GCB has no concept of dynamically creating substitutions or
+    # passing ENV vars between steps, so the best we can do is to create a file
+    # containing our tag in the shared workspace which other steps can inspect.
+    step {
+      name = "bash"
+      script = (
+        var.cloudbuild_trigger_tag != "" ?
+        "$TAG_NAME > /workspace/git_tag && cat /workspace/git_tag" :
+        "date +'0.3.%s-incompatible' > /workspace/git_tag && cat /workspace/git_tag"
+      )
+    }
+    ### Build the recovery binary and upload it to GCS.
+    # Build an image containing the trusted applet artifacts with the Dockerfile.
+    step {
+      name = "gcr.io/cloud-builders/docker"
+      entrypoint = "bash"
+      args = [
+        "-c",
+        <<-EOT
+        docker build \
+          --build-arg=TAMAGO_VERSION=${var.tamago_version} \
+          --build-arg=ARMORY_UMS_VERSION=${var.armory_ums_version} \
+          -t builder-image \
+          recovery
+       EOT
+      ]
+    }
+    # Prepare a container with a copy of the artifacts.
+    step {
+      name = "gcr.io/cloud-builders/docker"
+      args = [
+        "create",
+        "--name",
+        "builder_scratch",
+        "builder-image",
+      ]
+    }
+    # Copy the artifacts from the container to the Cloud Build VM.
+    step {
+      name = "gcr.io/cloud-builders/docker"
+      args = [
+       "cp",
+       "builder_scratch:/build/armory-ums",
+       "output",
+      ]
+    }
+    # List the artifacts.
+    step {
+      name = "bash"
+      script = "ls output"
+    }
+    # Copy the artifacts from the Cloud Build VM to GCS.
+    step {
+      name = "gcr.io/cloud-builders/gcloud"
+      entrypoint = "bash"
+      args = [
+        "-c",
+        <<-EOT
+        gcloud storage cp \
+          output/armory-ums.imx \
+          gs://${var.firmware_bucket_prefix}-${var.log_shard}/$(sha256sum output/armory-ums.imx | cut -f1 -d" ")
+        EOT
+      ]
+    }
+    # HAB: Create SRK table & hash
+    # TODO(al): we should probably store the generated SRK/hash in a GCS bucket
+    # and then compare each time to ensure that nothing bad has happened with
+    # our PKI.
+    step {
+      name = "golang"
+      entrypoint = "bash"
+      args = [
+        "-c",
+        <<-EOT
+          go run github.com/usbarmory/crucible/cmd/habtool@c77ff4b67b3cd86b4328ecbcad23394d54638ddc \
+          -z gcp \
+          -1 projects/armored-witness/locations/us-central1/caPools/aw-hab-ca-pool-rev0-${var.env}/certificateAuthorities/hab-srk1-rev4-${var.env} \
+          -2 projects/armored-witness/locations/us-central1/caPools/aw-hab-ca-pool-rev0-${var.env}/certificateAuthorities/hab-srk2-rev4-${var.env} \
+          -3 projects/armored-witness/locations/us-central1/caPools/aw-hab-ca-pool-rev0-${var.env}/certificateAuthorities/hab-srk3-rev4-${var.env} \
+          -4 projects/armored-witness/locations/us-central1/caPools/aw-hab-ca-pool-rev0-${var.env}/certificateAuthorities/hab-srk4-rev4-${var.env} \
+          -o output/gcp_hab_rev4_${var.env}_srk.hash \
+          -t output/gcp_hab_rev4_${var.env}_srk.srk
+        EOT
+      ]
+    }
+    # Assert SRK hash value
+    step {
+      name = "golang"
+      entrypoint = "bash"
+      args = [
+        "-c",
+        <<-EOT
+        if [ -n "${var.srk_hash}"]; then \
+          echo "$(od -An -tx1 output/gcp_hab_rev4_${var.env}_srk.hash | tr -d ' \n')" >> /workspace/got_srk_hash; \
+          if [ "${var.srk_hash}" != $(cat /workspace/got_srk_hash) ]; then \
+            echo "Got SRK hash \"$(cat /workspace/got_srk_hash)\""; \
+            echo "Expected SRK hash '${var.srk_hash}'"; \
+            exit 1; \
+          fi; \
+        fi
+        EOT
+      ]
+    }
+    step {
+      name = "golang"
+      entrypoint = "bash"
+      args = [
+        "-c",
+        <<-EOT
+        go run github.com/usbarmory/crucible/cmd/habtool@c77ff4b67b3cd86b4328ecbcad23394d54638ddc \
+          -z gcp \
+          -a projects/1071548024491/locations/us-central1/caPools/aw-hab-ca-pool-rev0-${var.env}/certificates/hab-csf1-rev4-2-${var.env} \
+          -A projects/armored-witness/locations/global/keyRings/hab-${var.env}/cryptoKeys/hab-csf1-rev4-${var.env}/cryptoKeyVersions/${var.hab_key_version} \
+          -b projects/1071548024491/locations/us-central1/caPools/aw-hab-ca-pool-rev0-${var.env}/certificates/hab-img1-rev4-2-${var.env} \
+          -B projects/armored-witness/locations/global/keyRings/hab-${var.env}/cryptoKeys/hab-img1-rev4-${var.env}/cryptoKeyVersions/${var.hab_key_version} \
+          -x 1 \
+          -s \
+          -t output/gcp_hab_rev4_${var.env}_srk.srk \
+          -i output/armory-ums.imx \
+          -o output/armory-ums.csf
+        EOT
+      ]
+    }
+    # Copy the HAB signature into the CAS
+    step {
+      name = "gcr.io/cloud-builders/gcloud"
+      entrypoint = "bash"
+      args = [
+        "-c",
+        <<-EOT
+        gcloud storage cp \
+          output/armory-ums.csf \
+          gs://${var.firmware_bucket_prefix}-${var.log_shard}/$(sha256sum output/armory-ums.csf | cut -f1 -d" ")
+        EOT
+      ]
+    }
+    ### Construct log entry / Claimant Model statement.
+    # This step needs to be a bash script in order to read the tag content
+    # from file.
+    step {
+      name = "golang"
+      entrypoint = "bash"
+      args = [
+        "-c",
+        <<-EOT
+        go run github.com/transparency-dev/armored-witness/cmd/manifest@main \
+          create \
+          --git_tag=$(cat /workspace/git_tag) \
+          --git_commit_fingerprint=${var.armory_ums_version} \
+          --firmware_file=output/armory-ums.imx \
+          --firmware_type=RECOVERY \
+          --tamago_version=${var.tamago_version} \
+          --hab_signature_file=output/armory-ums.csf \
+          --hab_target=${var.env} \
+          --raw \
+          --output_file=output/recovery_manifest_unsigned.json
+        EOT
+      ]
+    }
+    # Sign the log entry.
+    step {
+      name = "golang"
+      args = [
+        "go",
+        "run",
+        "github.com/transparency-dev/armored-witness/cmd/sign@main",
+        "--project_name=$PROJECT_ID",
+        "--release=${var.env}",
+        "--artefact=os1",
+        "--manifest_file=output/recovery_manifest_unsigned.json",
+        "--output_file=output/recovery_manifest",
+      ]
+    }
+     # Print the content of the signed manifest.
+    step {
+      name = "bash"
+      script = "cat output/recovery_manifest"
+    }
+    ### Write the firmware release to the CI transparency log.
+    # Copy the signed note to the sequence bucket, preparing to write to log.
+    #
+    # Use the SHA256 of the manifest as the name of the manifest. This allows
+    # multiple triggers to run without colliding.
+    step {
+      name = "gcr.io/cloud-builders/gcloud"
+      entrypoint = "bash"
+      args = [
+        "-c",
+        <<-EOT
+        gcloud storage cp output/recovery_manifest \
+        gs://${var.log_name_prefix}-${var.log_shard}/${var.entries_dir}/$(sha256sum output/recovery_manifest | cut -f1 -d" ")/trusted_os_manifest_both
+        EOT
+      ]
+    }
+    # Sequence log entry.
+    step {
+      name = "gcr.io/cloud-builders/gcloud"
+      entrypoint = "bash"
+      args = [
+        "-c",
+        <<-EOT
+        gcloud functions call sequence \
+        --data="{
+          \"entriesDir\": \"${var.entries_dir}/$(sha256sum output/recovery_manifest | cut -f1 -d" ")\",
+          \"origin\": \"${var.origin_prefix}/${var.log_shard}\",
+          \"bucket\": \"${var.log_name_prefix}-${var.log_shard}\",
+          \"kmsKeyName\": \"ft-log-${var.env}\",
+          \"kmsKeyRing\": \"firmware-release-${var.env}\",
+          \"kmsKeyVersion\": ${var.log_shard},
+          \"kmsKeyLocation\": \"global\",
+          \"noteKeyName\": \"transparency.dev-aw-ftlog-${var.env}-${var.log_shard}\",
+          \"checkpointCacheControl\": \"${var.checkpoint_cache}\"
+        }"
+        EOT
+      ]
+    }
+    # Integrate log entry.
+    step {
+      name = "gcr.io/cloud-builders/gcloud"
+      entrypoint = "bash"
+      args = [
+        "-c",
+        <<-EOT
+        gcloud functions call integrate \
+        --data='{
+          "origin": "${var.origin_prefix}/${var.log_shard}",
+          "bucket": "${var.log_name_prefix}-${var.log_shard}",
+          "kmsKeyName": "ft-log-${var.env}",
+          "kmsKeyRing": "firmware-release-${var.env}",
+          "kmsKeyVersion": ${var.log_shard},
+          "kmsKeyLocation": "global",
+          "noteKeyName": "transparency.dev-aw-ftlog-${var.env}-${var.log_shard}",
+          "checkpointCacheControl": "${var.checkpoint_cache}"
+        }'
+        EOT
+      ]
+    }
+    # Clean up the file we added to the _ENTRIES_DIR bucket now that it's been
+    # integrated to the log.
+    step {
+      name = "gcr.io/cloud-builders/gcloud"
+      entrypoint = "bash"
+      args = [
+        "-c",
+        <<-EOT
+        gcloud storage rm \
+        gs://${var.log_name_prefix}-${var.log_shard}/${var.entries_dir}/$(sha256sum output/recovery_manifest | cut -f1 -d" ")/trusted_os_manifest_both
+        EOT
+      ]
+    }
+  }
+}
+
 # TODO(jayhou): add GCF stuff.

--- a/deployment/build_and_release/modules/release/main.tf
+++ b/deployment/build_and_release/modules/release/main.tf
@@ -556,12 +556,12 @@ resource "google_cloudbuild_trigger" "build_recovery" {
         <<-EOT
           go run github.com/usbarmory/crucible/cmd/habtool@c77ff4b67b3cd86b4328ecbcad23394d54638ddc \
           -z gcp \
-          -1 projects/armored-witness/locations/us-central1/caPools/aw-hab-ca-pool-rev0-${var.env}/certificateAuthorities/hab-srk1-rev4-${var.env} \
-          -2 projects/armored-witness/locations/us-central1/caPools/aw-hab-ca-pool-rev0-${var.env}/certificateAuthorities/hab-srk2-rev4-${var.env} \
-          -3 projects/armored-witness/locations/us-central1/caPools/aw-hab-ca-pool-rev0-${var.env}/certificateAuthorities/hab-srk3-rev4-${var.env} \
-          -4 projects/armored-witness/locations/us-central1/caPools/aw-hab-ca-pool-rev0-${var.env}/certificateAuthorities/hab-srk4-rev4-${var.env} \
-          -o output/gcp_hab_rev4_${var.env}_srk.hash \
-          -t output/gcp_hab_rev4_${var.env}_srk.srk
+          -1 projects/armored-witness/locations/us-central1/caPools/aw-hab-ca-pool-rev0-${var.env}/certificateAuthorities/hab-srk1-rev${var.hab_revision}-${var.env} \
+          -2 projects/armored-witness/locations/us-central1/caPools/aw-hab-ca-pool-rev0-${var.env}/certificateAuthorities/hab-srk2-rev${var.hab_revision}-${var.env} \
+          -3 projects/armored-witness/locations/us-central1/caPools/aw-hab-ca-pool-rev0-${var.env}/certificateAuthorities/hab-srk3-rev${var.hab_revision}-${var.env} \
+          -4 projects/armored-witness/locations/us-central1/caPools/aw-hab-ca-pool-rev0-${var.env}/certificateAuthorities/hab-srk4-rev${var.hab_revision}-${var.env} \
+          -o output/gcp_hab_rev${var.hab_revision}_${var.env}_srk.hash \
+          -t output/gcp_hab_rev${var.hab_revision}_${var.env}_srk.srk
         EOT
       ]
     }
@@ -573,7 +573,7 @@ resource "google_cloudbuild_trigger" "build_recovery" {
         "-c",
         <<-EOT
         if [ -n "${var.srk_hash}"]; then \
-          echo "$(od -An -tx1 output/gcp_hab_rev4_${var.env}_srk.hash | tr -d ' \n')" >> /workspace/got_srk_hash; \
+          echo "$(od -An -tx1 output/gcp_hab_rev${var.hab_revision}_${var.env}_srk.hash | tr -d ' \n')" >> /workspace/got_srk_hash; \
           if [ "${var.srk_hash}" != $(cat /workspace/got_srk_hash) ]; then \
             echo "Got SRK hash \"$(cat /workspace/got_srk_hash)\""; \
             echo "Expected SRK hash '${var.srk_hash}'"; \
@@ -591,13 +591,13 @@ resource "google_cloudbuild_trigger" "build_recovery" {
         <<-EOT
         go run github.com/usbarmory/crucible/cmd/habtool@c77ff4b67b3cd86b4328ecbcad23394d54638ddc \
           -z gcp \
-          -a projects/1071548024491/locations/us-central1/caPools/aw-hab-ca-pool-rev0-${var.env}/certificates/hab-csf1-rev4-2-${var.env} \
-          -A projects/armored-witness/locations/global/keyRings/hab-${var.env}/cryptoKeys/hab-csf1-rev4-${var.env}/cryptoKeyVersions/${var.hab_key_version} \
-          -b projects/1071548024491/locations/us-central1/caPools/aw-hab-ca-pool-rev0-${var.env}/certificates/hab-img1-rev4-2-${var.env} \
-          -B projects/armored-witness/locations/global/keyRings/hab-${var.env}/cryptoKeys/hab-img1-rev4-${var.env}/cryptoKeyVersions/${var.hab_key_version} \
+          -a projects/1071548024491/locations/us-central1/caPools/aw-hab-ca-pool-rev0-${var.env}/certificates/hab-csf1-rev${var.hab_revision}${var.hab_leaf_minor}-${var.env} \
+          -A projects/armored-witness/locations/global/keyRings/hab-${var.env}/cryptoKeys/hab-csf1-rev${var.hab_revision}-${var.env}/cryptoKeyVersions/${var.hab_key_version} \
+          -b projects/1071548024491/locations/us-central1/caPools/aw-hab-ca-pool-rev0-${var.env}/certificates/hab-img1-rev${var.hab_revision}${var.hab_leaf_minor}-${var.env} \
+          -B projects/armored-witness/locations/global/keyRings/hab-${var.env}/cryptoKeys/hab-img1-rev${var.hab_revision}-${var.env}/cryptoKeyVersions/${var.hab_key_version} \
           -x 1 \
           -s \
-          -t output/gcp_hab_rev4_${var.env}_srk.srk \
+          -t output/gcp_hab_rev${var.hab_revision}_${var.env}_srk.srk \
           -i output/armory-ums.imx \
           -o output/armory-ums.csf
         EOT

--- a/deployment/build_and_release/modules/release/variables.tf
+++ b/deployment/build_and_release/modules/release/variables.tf
@@ -140,3 +140,13 @@ variable "hab_key_version" {
   type        = number
   description = "Key version of the keys to sign CSF and IMG payloads"
 }
+
+variable "hab_revision" {
+  description = "Revision count for HAB PKI certs. This must be incremented if these certs are regenerated for any reason"
+}
+
+variable "hab_leaf_minor" {
+  description = "Revision count for CSF and IMG certs. This allows us to optionally regenerate these certs, while leaving the SRK ones in place."
+  type = string
+  default = ""
+}

--- a/deployment/build_and_release/modules/release/variables.tf
+++ b/deployment/build_and_release/modules/release/variables.tf
@@ -68,6 +68,11 @@ variable "tamago_version" {
   description = "TamaGo version to compile with"
 }
 
+variable "armory_ums_version" {
+  type        = string
+  description = "Full git commit hash for the armory-ums repo to use when building the recovery image"
+}
+
 variable "entries_dir" {
   type        = string
   description = "Specifies where the to-be-sequenced entries are"
@@ -129,4 +134,9 @@ variable "srk_hash" {
     and MUST NOT be changed unless you know very well what you're doing,
     otherwise devices will be bricked!
   EOT
+}
+
+variable "hab_key_version" {
+  type        = number
+  description = "Key version of the keys to sign CSF and IMG payloads"
 }


### PR DESCRIPTION
I have copied over `hab_revision` and `hab_leaf_minor` from the hab module for now, whereas ideally we could use the values there directly. I think we need to do something like [this](https://developer.hashicorp.com/terraform/language/state/remote-state-data) with Terragrunt, but thinking we should talk it over first and then do it in a separate PR. Here's something I found wrt Terragrunt: https://github.com/gruntwork-io/terragrunt/issues/1150