### PR TITLE
Create and reference output values for the `hab_pki` module.

### DIFF
--- a/deployment/build_and_release/live/ci/terragrunt.hcl
+++ b/deployment/build_and_release/live/ci/terragrunt.hcl
@@ -36,9 +36,6 @@ inputs = merge(
 
     # HAB-related
     srk_hash = "b8ba457320663bf006accd3c57e06720e63b21ce5351cb91b4650690bb08d85a"
-    hab_key_version = 1
-    hab_revision = 4
-    hab_leaf_minor = "-2"
 
     # Pinned at tag [v20231018](https://github.com/usbarmory/armory-ums/releases/tag/v20231018)
     armory_ums_version: "850baf54809bd29548d6f817933240043400a4e1"

--- a/deployment/build_and_release/live/prod/terragrunt.hcl
+++ b/deployment/build_and_release/live/prod/terragrunt.hcl
@@ -35,9 +35,6 @@ inputs = merge(
 
     # HAB-related
     srk_hash = "TODO"
-    hab_key_version = 1
-    hab_revision = 0
-    hab_leaf_minor = "-0"
 
     # Pinned at tag [v20231018](https://github.com/usbarmory/armory-ums/releases/tag/v20231018)
     armory_ums_version: "850baf54809bd29548d6f817933240043400a4e1"

--- a/deployment/build_and_release/modules/release/variables.tf
+++ b/deployment/build_and_release/modules/release/variables.tf
@@ -135,21 +135,6 @@ variable "srk_hash" {
   EOT
 }
 
-variable "hab_key_version" {
-  type        = number
-  description = "Key version of the keys to sign CSF and IMG payloads"
-}
-
-variable "hab_revision" {
-  description = "Revision count for HAB PKI certs. This must be incremented if these certs are regenerated for any reason"
-}
-
-variable "hab_leaf_minor" {
-  description = "Revision count for CSF and IMG certs. This allows us to optionally regenerate these certs, while leaving the SRK ones in place."
-  type        = string
-  default     = ""
-}
-
 variable "firmware_base_url" {
   description = "Base URL used to construct the log and firmware bucket URLs"
   type = string

--- a/deployment/hab_pki/modules/hab_pki/outputs.tf
+++ b/deployment/hab_pki/modules/hab_pki/outputs.tf
@@ -1,0 +1,26 @@
+output "hab_img_id" {
+  description = "HAB IMG cert for the first SRK intermediate"
+  value       = google_privateca_certificate.hab_img[1].id
+}
+
+output "hab_img_key" {
+  description = "HAB IMG key"
+  value       = data.google_kms_crypto_key_version.hab_img[1].name
+}
+
+output "hab_csf_id" {
+  description = "HAB CSF cert for the first SRK intermediate"
+  value       = google_privateca_certificate.hab_csf[1].id
+}
+
+output "hab_csf_key" {
+  description = "HAB CSF key"
+  value       = data.google_kms_crypto_key_version.hab_csf[1].name
+}
+
+output "hab_srk_ca_ids" {
+  description = "HAB SRK intermediates"
+  value = {
+    for k, hab_srk in google_privateca_certificate_authority.hab_srk : k => hab_srk.id
+  }
+}


### PR DESCRIPTION
After applying the output values in CI `hab_pki`, the plan of CI `build_and_release` looks like this differs in just the project number -> project id, and the `.srk` and `.hash` names. I removed the revision and env from the names because it looks like these names are just referenced locally and can be simplified.