### PR TITLE
Use output values for log buckets and artefact buckets.

### DIFF
--- a/deployment/api_transparency_dev/terraform.tfvars
+++ b/deployment/api_transparency_dev/terraform.tfvars
@@ -1,4 +1,5 @@
 project_id               = "1071548024491"
+project_name             = "armored-witness"
 signing_keyring_location = "global"
 tf_state_location        = "europe-west2"
 
@@ -8,11 +9,8 @@ serve_domain = "api.transparency.dev"
 lb_name = "transparency-dev-lb"
 
 # TODO(mhutchinson): this is the old env and should be switched to the following
- distributor_prod_host = "distributor-service-prod-oxxl2d5jeq-uc.a.run.app"
+distributor_prod_host = "distributor-service-prod-oxxl2d5jeq-uc.a.run.app"
 distributor_prod_port = 443
 
 distributor_ci_host = "distributor-service-ci-oxxl2d5jeq-uc.a.run.app"
 distributor_ci_port = 443
-
-ci_bucket_count = 3
-prod_bucket_count = 2

--- a/deployment/api_transparency_dev/variables.tf
+++ b/deployment/api_transparency_dev/variables.tf
@@ -1,12 +1,20 @@
 variable "project_id" {
+  type = number
   description = "The project ID to host the cluster in"
 }
 
+variable "project_name" {
+  type = string
+  description = "The string project ID"
+}
+
 variable "signing_keyring_location" {
+  type = string
   description = "The GCP location to create the signing keyring"
 }
 
 variable "tf_state_location" {
+  type = string
   description = "The GCP location to store Terraform remote state"
 }
 
@@ -21,6 +29,7 @@ variable "tls" {
 }
 
 variable "distributor_prod_host" {
+  type = string
   description = "Host name serving distributor service API (prod)"
 }
 variable "distributor_prod_port" {
@@ -28,6 +37,7 @@ variable "distributor_prod_port" {
   type        = number
 }
 variable "distributor_ci_host" {
+  type = string
   description = "Host name serving distributor service API (ci)"
 }
 variable "distributor_ci_port" {
@@ -35,15 +45,7 @@ variable "distributor_ci_port" {
   type        = number
 }
 
-variable "ci_bucket_count" {
-  description = "The number of log and firmware buckets in CI (each)"
-  type        = number
-}
-variable "prod_bucket_count" {
-  description = "The number of log and firmware buckets in prod (each)"
-  type        = number
-}
-
 variable "lb_name" {
+  type = string
   description = "Name of the load balancer"
 }

--- a/deployment/build_and_release/modules/release/outputs.tf
+++ b/deployment/build_and_release/modules/release/outputs.tf
@@ -1,0 +1,13 @@
+output "firmware_log_buckets" {
+  description = "Firmware log GCS bucket names"
+  value = {
+    for k, bucket in google_storage_bucket.firmware_log : k => bucket.name
+  }
+}
+
+output "firmware_artefact_buckets" {
+  description = "Firmware artefact GCS bucket names"
+  value = {
+    for k, bucket in google_storage_bucket.firmware : k => bucket.name
+  }
+}


### PR DESCRIPTION
This PR means we won't have to add a new path_rule each time we roll a log. It will be `dynamic`ally created based on the output values of the `build_and_release` module.