### PR TITLE
Add prod SRK hash assertion value.

### DIFF
--- a/deployment/build_and_release/live/prod/terragrunt.hcl
+++ b/deployment/build_and_release/live/prod/terragrunt.hcl
@@ -25,10 +25,9 @@ inputs = merge(
     os_public_key1 = "transparency.dev-aw-os-prod+c31218b7+AV7mmRamQp6VC9CutzSXzqtNhYNyNmQQRcLX07F6qlC1"
     os_public_key2 = "transparency.dev-aw-os-prod-wave0+fee4bbcc+AQF1ml5TrXJkhnrJRJz5QsCZAYuCj9oOD5VpUdghWOiQ"
     bee = "1"
-    debug = "1"
 
     # HAB-related
-    srk_hash = "TODO"
+    srk_hash = "77e021cc51b5547fb0c2192fb32710bfa89b4bbaa7dab5f97fc585f673b0b236"
 
     # Pinned at tag [v20231018](https://github.com/usbarmory/armory-ums/releases/tag/v20231018)
     armory_ums_version: "850baf54809bd29548d6f817933240043400a4e1"


### PR DESCRIPTION
From running:
```
go run github.com/usbarmory/crucible/cmd/habtool@c77ff4b67b3cd86b4328ecbcad23394d54638ddc \
  -z gcp \
  -1 projects/armored-witness/locations/us-central1/caPools/aw-hab-ca-pool-rev0-prod/certificateAuthorities/hab-srk1-rev0-prod \
  -2 projects/armored-witness/locations/us-central1/caPools/aw-hab-ca-pool-rev0-prod/certificateAuthorities/hab-srk2-rev0-prod \
  -3 projects/armored-witness/locations/us-central1/caPools/aw-hab-ca-pool-rev0-prod/certificateAuthorities/hab-srk3-rev0-prod \
  -4 projects/armored-witness/locations/us-central1/caPools/aw-hab-ca-pool-rev0-prod/certificateAuthorities/hab-srk4-rev0-prod \
  -o output/gcp_hab_srk.hash \
  -t output/gcp_hab_srk.srk
```