### PR TITLE
Remove TODOs

### DIFF
--- a/cmd/provision/main.go
+++ b/cmd/provision/main.go
@@ -333,10 +333,6 @@ func prepareFlashJobs(firmwares *firmwares) (*firmwareJobs, error) {
 
 // waitAndProvision waits for a fresh armored witness device to be detected, and then provisions it.
 func waitAndProvision(ctx context.Context, fw *firmwares) error {
-	// Per-device prep:
-	// TODO: sign bootloader and recovery images.
-	// TODO: store signed bootloader and recovery images somewhere durable.
-
 	klog.Infof(operPlease, "please ensure boot switch is set to USB, and then connect unprovisioned device")
 
 	recoveryHAB := append(fw.recovery.bundle.Firmware, fw.recovery.bundle.HABSignature...)
@@ -478,11 +474,8 @@ func waitAndProvision(ctx context.Context, fw *firmwares) error {
 		}
 	}
 
-	// TODO: Reboot device.
 	klog.Infof(operPlease, "please reboot device")
 	klog.Info("Waiting for device to boot...")
-
-	// TODO: Use HID to access witness public keys from device and store somewhere durable.
 
 	klog.Infof("✅ Witness ID %s provisioned", s.Witness.Identity)
 

--- a/cmd/verify/main.go
+++ b/cmd/verify/main.go
@@ -162,9 +162,6 @@ type verifier struct {
 
 // fetchRecoveryFirmware returns a recovery image suitable for use on the armored witness,
 // and which has been verified to be present in the firmware transparency log.
-//
-// TODO: this will need updating to fetch a specific version of the image which has
-// been signed for the attached device.
 func (v *verifier) fetchRecoveryFirmware(ctx context.Context) error {
 	logFetcher := fetcher.New(v.logBaseURL)
 	binFetcher := fetcher.BinaryFetcher(fetcher.New(v.binBaseURL))


### PR DESCRIPTION
- Remove obsolete TODOs.
- Replace device settle sleep with an active probe
