### PR TITLE
Use bash args instead of script.

### DIFF
--- a/deployment/build_and_release/modules/release/main.tf
+++ b/deployment/build_and_release/modules/release/main.tf
@@ -271,8 +271,8 @@ resource "google_cloudbuild_trigger" "applet_build" {
       args = [
         "-c",
         var.cloudbuild_trigger_tag != "" ?
-        "echo $TAG_NAME > /workspace/git_tag && cat /workspace/git_tag" :
-        "date +'0.3.%s-incompatible' > /workspace/git_tag && cat /workspace/git_tag"
+          "echo $TAG_NAME > /workspace/git_tag && cat /workspace/git_tag" :
+          "date +'0.3.%s-incompatible' > /workspace/git_tag && cat /workspace/git_tag"
       ]
     }
     ### Build the Trusted Applet and upload it to GCS.
@@ -494,8 +494,8 @@ resource "google_cloudbuild_trigger" "os_build" {
       args = [
         "-c",
         var.cloudbuild_trigger_tag != "" ?
-        "echo $TAG_NAME > /workspace/git_tag && cat /workspace/git_tag" :
-        "date +'0.3.%s-incompatible' > /workspace/git_tag && cat /workspace/git_tag"
+          "echo $TAG_NAME > /workspace/git_tag && cat /workspace/git_tag" :
+          "date +'0.3.%s-incompatible' > /workspace/git_tag && cat /workspace/git_tag"
       ]
     }
     ### Build the Trusted OS and upload it to GCS.
@@ -727,8 +727,8 @@ resource "google_cloudbuild_trigger" "build_recovery" {
       args = [
         "-c",
         var.cloudbuild_trigger_tag != "" ?
-        "echo $TAG_NAME > /workspace/git_tag && cat /workspace/git_tag" :
-        "date +'0.3.%s-incompatible' > /workspace/git_tag && cat /workspace/git_tag"
+          "echo $TAG_NAME > /workspace/git_tag && cat /workspace/git_tag" :
+          "date +'0.3.%s-incompatible' > /workspace/git_tag && cat /workspace/git_tag"
       ]
     }
     ### Build the recovery binary and upload it to GCS.
@@ -999,8 +999,8 @@ resource "google_cloudbuild_trigger" "build_boot" {
       args = [
         "-c",
         var.cloudbuild_trigger_tag != "" ?
-        "echo $TAG_NAME > /workspace/git_tag && cat /workspace/git_tag" :
-        "date +'0.0.%s-incompatible' > /workspace/git_tag && cat /workspace/git_tag"
+          "echo $TAG_NAME > /workspace/git_tag && cat /workspace/git_tag" :
+          "date +'0.0.%s-incompatible' > /workspace/git_tag && cat /workspace/git_tag"
       ]
     }
     ### Build the bootloader binary and upload it to GCS.

--- a/deployment/build_and_release/modules/release/main.tf
+++ b/deployment/build_and_release/modules/release/main.tf
@@ -268,11 +268,12 @@ resource "google_cloudbuild_trigger" "applet_build" {
     # containing our tag in the shared workspace which other steps can inspect.
     step {
       name = "bash"
-      script = (
+      args = [
+        "-c",
         var.cloudbuild_trigger_tag != "" ?
         "echo $TAG_NAME > /workspace/git_tag && cat /workspace/git_tag" :
         "date +'0.3.%s-incompatible' > /workspace/git_tag && cat /workspace/git_tag"
-      )
+      ]
     }
     ### Build the Trusted Applet and upload it to GCS.
     # Build an image containing the Trusted OS artifacts with the Dockerfile.
@@ -490,11 +491,12 @@ resource "google_cloudbuild_trigger" "os_build" {
     # containing our tag in the shared workspace which other steps can inspect.
     step {
       name = "bash"
-      script = (
+      args = [
+        "-c",
         var.cloudbuild_trigger_tag != "" ?
         "echo $TAG_NAME > /workspace/git_tag && cat /workspace/git_tag" :
         "date +'0.3.%s-incompatible' > /workspace/git_tag && cat /workspace/git_tag"
-      )
+      ]
     }
     ### Build the Trusted OS and upload it to GCS.
     # Build an image containing the Trusted OS artifacts with the Dockerfile.
@@ -722,11 +724,12 @@ resource "google_cloudbuild_trigger" "build_recovery" {
     # containing our tag in the shared workspace which other steps can inspect.
     step {
       name = "bash"
-      script = (
+      args = [
+        "-c",
         var.cloudbuild_trigger_tag != "" ?
         "echo $TAG_NAME > /workspace/git_tag && cat /workspace/git_tag" :
         "date +'0.3.%s-incompatible' > /workspace/git_tag && cat /workspace/git_tag"
-      )
+      ]
     }
     ### Build the recovery binary and upload it to GCS.
     # Build an image containing the trusted applet artifacts with the Dockerfile.
@@ -993,11 +996,12 @@ resource "google_cloudbuild_trigger" "build_boot" {
     # containing our tag in the shared workspace which other steps can inspect.
     step {
       name = "bash"
-      script = (
+      args = [
+        "-c",
         var.cloudbuild_trigger_tag != "" ?
         "echo $TAG_NAME > /workspace/git_tag && cat /workspace/git_tag" :
-        "date +'0.0.%s-incompatible' > /workspace/git_tag && cat /workspace/git_tag"
-      )
+        "date +'0.3.%s-incompatible' > /workspace/git_tag && cat /workspace/git_tag"
+      ]
     }
     ### Build the bootloader binary and upload it to GCS.
     # Use the dockerfile to build an image containing the bootloader artifact.

--- a/deployment/build_and_release/modules/release/main.tf
+++ b/deployment/build_and_release/modules/release/main.tf
@@ -1000,7 +1000,7 @@ resource "google_cloudbuild_trigger" "build_boot" {
         "-c",
         var.cloudbuild_trigger_tag != "" ?
         "echo $TAG_NAME > /workspace/git_tag && cat /workspace/git_tag" :
-        "date +'0.3.%s-incompatible' > /workspace/git_tag && cat /workspace/git_tag"
+        "date +'0.0.%s-incompatible' > /workspace/git_tag && cat /workspace/git_tag"
       ]
     }
     ### Build the bootloader binary and upload it to GCS.


### PR DESCRIPTION
"Scripts don't directly support substitutions..." (from https://cloud.google.com/build/docs/configuring-builds/run-bash-scripts#using_substitutions_with_the_script_field), and `$TAG_NAME` is a substitution.

Rather than mapping the substitution, I've decided to use args instead because it displays more logging in Cloud Build.