### PR TITLE
Fix small issues in verify

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/transparency-dev/merkle v0.0.2
 	github.com/transparency-dev/serverless-log v0.0.0-20231215122707-66f68a7705f5
 	github.com/usbarmory/armory-boot v0.0.0-20230922092524-e66d926bc36c
-	github.com/usbarmory/hid v0.0.0-20210318233634-85ced88a1ffe
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9
 	golang.org/x/mod v0.16.0
 	google.golang.org/protobuf v1.33.0

--- a/go.sum
+++ b/go.sum
@@ -107,8 +107,6 @@ github.com/transparency-dev/serverless-log v0.0.0-20231215122707-66f68a7705f5 h1
 github.com/transparency-dev/serverless-log v0.0.0-20231215122707-66f68a7705f5/go.mod h1:rx4EB9NW4aZFJT5kxf6BWRWbZSThl36jv7O5o5r/qv8=
 github.com/usbarmory/armory-boot v0.0.0-20230922092524-e66d926bc36c h1:qQL3CljMNrk9TyG8EUvCAPU7/bTVitJMhqlKSNhskis=
 github.com/usbarmory/armory-boot v0.0.0-20230922092524-e66d926bc36c/go.mod h1:20DIzHJntbLDOptGT7TOm8DkT5mL2jRyzPzVXAYVHJ8=
-github.com/usbarmory/hid v0.0.0-20210318233634-85ced88a1ffe h1:WWop+y0QNxBEZAKu9xlNiZWgo5+y5VkzlyngVMViBlE=
-github.com/usbarmory/hid v0.0.0-20210318233634-85ced88a1ffe/go.mod h1:8ScVLh9aty8MLtypACxU7JdF5u2y2rEfhx3zJPS/tPc=
 github.com/usbarmory/tamago v0.0.0-20220823080407-04f05cf2a5a3/go.mod h1:Lok79mjbJnhoBGqhX5cCUsZtSemsQF5FNZW+2R1dRr8=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=

--- a/internal/device/recovery.go
+++ b/internal/device/recovery.go
@@ -93,7 +93,7 @@ func waitForBlockDevice(ctx context.Context, glob string, f func() error) (strin
 	}()
 
 	// Set up the watcher to look for events in /dev only.
-	if err := watcher.Add("/dev/disk/by-id"); err != nil {
+	if err := watcher.Add(filepath.Dir(glob)); err != nil {
 		return "", fmt.Errorf("failed to add /dev to fs watcher: %v", err)
 	}
 

--- a/internal/device/sdp.go
+++ b/internal/device/sdp.go
@@ -27,7 +27,7 @@ import (
 	"github.com/usbarmory/armory-boot/sdp"
 	"k8s.io/klog/v2"
 
-	"github.com/usbarmory/hid"
+	"github.com/flynn/hid"
 )
 
 const (


### PR DESCRIPTION
This PR resolves a couple of small issues with the `verify` command:
- Compilation on OS X failed during linking due to two forks of the `hid` package being imported unintentionally
- The `blockdevs` path wasn't being used to configure the `fsnotify` watcher.
