### PR TITLE
Fix non-prod build version tag

### DIFF
--- a/deployment/build_and_release/modules/release/main.tf
+++ b/deployment/build_and_release/modules/release/main.tf
@@ -272,7 +272,7 @@ resource "google_cloudbuild_trigger" "applet_build" {
         "-c",
         var.cloudbuild_trigger_tag != "" ?
           "echo $TAG_NAME > /workspace/git_tag && cat /workspace/git_tag" :
-          "date +'0.3.%s-incompatible' > /workspace/git_tag && cat /workspace/git_tag"
+          "date +'v0.3.%s-incompatible' > /workspace/git_tag && cat /workspace/git_tag"
       ]
     }
     ### Build the Trusted Applet and upload it to GCS.


### PR DESCRIPTION
Prod builds use the name of the triggering git-tag as the contents of `/workspace/git_tag`, these must match a regex which requires they start with a `v` and continue with a semver string (defined [here](https://github.com/transparency-dev/armored-witness/blob/main/deployment/build_and_release/live/prod/terragrunt.hcl#L15-L17)).

non-prod builds echo a value into that file, this PR modifies that value to _also_ start with a `v`.