### PR TITLE
[verify_build] Distinguish between error and -ve verification

### DIFF
--- a/cmd/verify_build/cmd/continuous.go
+++ b/cmd/verify_build/cmd/continuous.go
@@ -160,9 +160,11 @@ func (m *Monitor) From(ctx context.Context, start uint64) error {
 			return fmt.Errorf("VerifyInclusionProof() %d: %v", i, err)
 		}
 
-		if err := m.rbv.Verify(ctx, i, rawLeaf); err != nil {
+		if success, err := m.rbv.Verify(ctx, i, rawLeaf); err != nil {
 			resErr = err
 			klog.Errorf("Error verifying index %d: %v", i, err)
+		} else if !success {
+			klog.Errorf("Log index %d appears unreproducible!", i)
 		}
 	}
 	if resErr != nil {

--- a/cmd/verify_build/cmd/single.go
+++ b/cmd/verify_build/cmd/single.go
@@ -67,8 +67,10 @@ func single(cmd *cobra.Command, args []string) {
 		klog.Exitf("Failed to read manifest from stdin: %v", err)
 	}
 	klog.V(1).Infof("Read %d bytes:\n%s", len(nbs), nbs)
-	if err := rbv.Verify(ctx, 0, nbs); err != nil {
-		klog.Exitf("Failed to verify manifest: %v", err)
+	if success, err := rbv.Verify(ctx, 0, nbs); err != nil {
+		klog.Exitf("Error while verifying manifest: %v", err)
+	} else if !success {
+		klog.Exitf("Failed to verify manifest!")
 	}
 	klog.Info("Success!")
 }


### PR DESCRIPTION
This PR separates "internal" failure in the process of reproducing a build from the comparison of resulting hashes, which allows the `single` command to return with a non-zero status on failure, but the `continuous` command to keep going.

We might want to consider returning some sort of richer return type that contains info about the reproduced binary (e.g. hashes etc.?) in the future, but this gets us out of the hole for now.