### PR TITLE
Configure prod devices to talk to bastion host

### DIFF
--- a/deployment/build_and_release/live/prod/terragrunt.hcl
+++ b/deployment/build_and_release/live/prod/terragrunt.hcl
@@ -29,6 +29,8 @@ inputs = merge(
     bee = "1"
     debug = "1"
 
+    bastion_addr = "bastion.glasklar.is:443"
+
     # HAB-related
     srk_hash = "77e021cc51b5547fb0c2192fb32710bfa89b4bbaa7dab5f97fc585f673b0b236"
 


### PR DESCRIPTION
This PR will enable bastion registration in production devices when a new release is created.

The majority of production AW devices have been provisioned on the bastion already, the remaining ones will be added as we hear back from the remaining custodians. It's not a problem for devices to attempt to register and be rejected (we've tested that with a CI device for a couple of weeks).

Toward #253 