### PR TITLE
Apply open CORS to public FT logs

### DIFF
--- a/deployment/build_and_release/modules/release/main.tf
+++ b/deployment/build_and_release/modules/release/main.tf
@@ -94,6 +94,11 @@ resource "google_storage_bucket" "firmware_log" {
   name                        = "armored-witness-firmware-log-${var.env}-${count.index}"
   storage_class               = "STANDARD"
   uniform_bucket_level_access = true
+
+  cors {
+    origin = ["*"]
+    method = ["GET"]
+  }
 }
 resource "google_storage_bucket_iam_member" "firmware_log_object_reader" {
   count = var.bucket_count


### PR DESCRIPTION
This PR adds open CORS headers for the GCS buckets containing the FT logs.

This change allows "log explorer" web UIs to display information from these logs.

These buckets are already publicly accessible and do not require any form authorisation to access them. (see https://youtu.be/vfAHa5GBLio?t=618 for background.)