### PR TITLE
Allow using different TamaGo version for recovery image

### DIFF
--- a/deployment/build_and_release/modules/presubmit_cloudbuild_triggers/main.tf
+++ b/deployment/build_and_release/modules/presubmit_cloudbuild_triggers/main.tf
@@ -170,7 +170,7 @@ resource "google_cloudbuild_trigger" "recovery_build" {
         "-c",
         <<-EOT
         docker build \
-          --build-arg=TAMAGO_VERSION=${var.tamago_version} \
+          --build-arg=TAMAGO_VERSION=${var.recovery_tamago_version} \
           --build-arg=ARMORY_UMS_VERSION=${var.armory_ums_version} \
           -t builder-image \
           recovery

--- a/deployment/build_and_release/modules/presubmit_cloudbuild_triggers/variables.tf
+++ b/deployment/build_and_release/modules/presubmit_cloudbuild_triggers/variables.tf
@@ -15,7 +15,13 @@ variable "origin_prefix" {
 
 variable "tamago_version" {
   type        = string
-  description = "TamaGo version to compile with"
+  description = "TamaGo version to compile armored-witness firmware with"
+}
+
+variable "recovery_tamago_version" {
+  type        = string
+  description = "TamaGo version to compile recovery image with"
+  default     = "1.22.6" # Pin to this by default since armory-ums is not yet compatible with 1.23.x
 }
 
 variable "armory_ums_version" {
@@ -97,3 +103,4 @@ variable "bastion_addr" {
   type        = string
   default     = ""
 }
+

--- a/deployment/build_and_release/modules/release/main.tf
+++ b/deployment/build_and_release/modules/release/main.tf
@@ -779,7 +779,7 @@ resource "google_cloudbuild_trigger" "build_recovery" {
         "-c",
         <<-EOT
         docker build \
-          --build-arg=TAMAGO_VERSION=${var.tamago_version} \
+          --build-arg=TAMAGO_VERSION=${var.recovery_tamago_version} \
           --build-arg=ARMORY_UMS_VERSION=${var.armory_ums_version} \
           -t builder-image \
           recovery

--- a/deployment/build_and_release/modules/release/variables.tf
+++ b/deployment/build_and_release/modules/release/variables.tf
@@ -61,6 +61,12 @@ variable "tamago_version" {
   description = "TamaGo version to compile with"
 }
 
+variable "recovery_tamago_version" {
+  type        = string
+  description = "TamaGo version to compile recovery image with"
+  default     = "1.22.6" # Pin to this by default since armory-ums is not yet compatible with 1.23.x
+}
+
 variable "armory_ums_version" {
   type        = string
   description = "Full git commit hash for the armory-ums repo to use when building the recovery image"
@@ -155,3 +161,4 @@ variable "verify_template" {
   description = "Template to use for verify_build step"
   type        = string
 }
+


### PR DESCRIPTION
Armory-UMS is not currently compatible with 1.23.1, so allow the TamaGo version for building the recovery image to be separately specified for now, and provide a known working default.