### PR TITLE
Hint in which direction to set the boot switch

### DIFF
--- a/cmd/provision/README.md
+++ b/cmd/provision/README.md
@@ -116,7 +116,7 @@ I1012 12:15:41.216803  292650 main.go:220] Loaded firmware artefacts.
 The tool will prompt you to ensure that a device is plugged in and has the boot switch set correctly:
 
 ```bash
-I1012 12:15:41.216806  292650 main.go:226] Operator, please ensure boot switch is set to USB, and then connect unprovisioned device 🙏
+I1012 12:15:41.216806  292650 main.go:226] Operator, please ensure boot switch is set to USB (towards RJ45 socket), and then connect unprovisioned device 🙏
 I1012 12:15:41.216809  292650 main.go:314] Waiting for device to be detected...
 ```
 
@@ -141,7 +141,7 @@ I1012 12:15:49.838553  292650 main.go:261]   Flashing in 4
 Once complete, it will ask you to flip the boot swith and reboot the device:
 
 ```bash
-I1012 12:18:10.816923  292650 main.go:278] Operator, please change boot switch to MMC, and then reboot device 🙏
+I1012 12:18:10.816923  292650 main.go:278] Operator, please change boot switch to MMC (away from RJ45 socket), and then reboot device 🙏
 I1012 12:18:10.816955  292650 main.go:279] Waiting for device to boot...
 I1012 12:18:10.816957  292650 main.go:337] Waiting for armored witness device to be detected...
 ```

--- a/cmd/provision/main.go
+++ b/cmd/provision/main.go
@@ -349,7 +349,7 @@ func prepareFlashJobs(firmwares *firmwares) (*firmwareJobs, error) {
 
 // waitAndProvision waits for a fresh armored witness device to be detected, and then provisions it.
 func waitAndProvision(ctx context.Context, fw *firmwares) error {
-	klog.Infof(operPlease, "please ensure boot switch is set to USB, and then connect unprovisioned device")
+	klog.Infof(operPlease, "please ensure boot switch is set to USB (towards RJ45 socket), and then connect unprovisioned device")
 
 	recoveryHAB := append(fw.recovery.bundle.Firmware, fw.recovery.bundle.HABSignature...)
 	klog.Infof("Recovery firmware is %d bytes + %d bytes HAB signature", len(fw.recovery.bundle.Firmware), len(fw.recovery.bundle.HABSignature))
@@ -400,7 +400,7 @@ func waitAndProvision(ctx context.Context, fw *firmwares) error {
 		}
 	}
 
-	klog.Infof(operPlease, "please change boot switch to MMC, and then reboot device")
+	klog.Infof(operPlease, "please change boot switch to MMC (away from RJ45 socket), and then reboot device")
 	klog.Info("Waiting for device to boot...")
 
 	p, dev, err := waitForU2FDevice(ctx)
@@ -459,7 +459,7 @@ func waitAndProvision(ctx context.Context, fw *firmwares) error {
 
 		klog.Infof("%d remaining firmware(s) to install", len(flashStages[1]))
 
-		klog.Infof(operPlease, "please change boot switch to USB, and then reboot device")
+		klog.Infof(operPlease, "please change boot switch to USB (towards RJ45 socket), and then reboot device")
 		klog.Info("Waiting for device to boot...")
 		// The device will initially be in HID mode (showing as "RecoveryMode" in the output to lsusb).
 		// So we'll detect it as such:
@@ -476,7 +476,7 @@ func waitAndProvision(ctx context.Context, fw *firmwares) error {
 		}
 		klog.Info("✅ Flashed Applet image")
 
-		klog.Infof(operPlease, "please change boot switch to MMC, and then reboot device")
+		klog.Infof(operPlease, "please change boot switch to MMC (away from RJ45 socket), and then reboot device")
 		klog.Info("Waiting for device to boot...")
 		p, dev, err = waitForU2FDevice(ctx)
 		if err != nil {

--- a/cmd/verify/README.md
+++ b/cmd/verify/README.md
@@ -73,9 +73,9 @@ I0311 18:44:50.422195  243805 main.go:96] Using template flag setting --firmware
 I0311 18:44:50.422205  243805 main.go:96] Using template flag setting --firmware_log_origin=transparency.dev/armored-witness/firmware_transparency/ci/2
 I0311 18:44:55.917161  243805 fetcher.go:88] Fetching RECOVERY bin from "8271e2a8ccefb6c4df48889fcbb35343511501e3bcd527317d9e63e2ac7349e3"
 I0311 18:44:56.047071  243805 main.go:218] Successfully fetched and verified recovery image
-I0311 18:44:56.047114  243805 main.go:219] ----------------------------------------------------------------------------------------------
-I0311 18:44:56.047124  243805 main.go:220] 🙏 Operator, please ensure boot switch is set to USB, and then connect device 🙏
-I0311 18:44:56.047132  243805 main.go:221] ----------------------------------------------------------------------------------------------
+I0311 18:44:56.047114  243805 main.go:219] -------------------------------------------------------------------------------------------------------------
+I0311 18:44:56.047124  243805 main.go:220] 🔷🔷🔷  🙏 Operator, please ensure boot switch is set to USB (towards RJ45 socket), and then connect device 🙏
+I0311 18:44:56.047132  243805 main.go:221] -------------------------------------------------------------------------------------------------------------
 I0311 18:44:56.047144  243805 main.go:224] Recovery firmware is 1924096 bytes + 16384 bytes HAB signature
 I0311 18:44:56.047168  243805 recovery.go:63] Waiting for device to be detected...
 I0311 18:45:16.109285  243805 sdp.go:85] found device 15a2:007d Freescale SemiConductor Inc  SE Blank 6UL
@@ -102,9 +102,9 @@ I0311 18:45:28.482947  243805 main.go:315]   ✅ TrustedOS: proof bundle checkpo
 I0311 18:45:28.505108  243805 main.go:292]   ✅ TrustedApplet: proof bundle is self-consistent
 I0311 18:45:28.505194  243805 main.go:315]   ✅ TrustedApplet: proof bundle checkpoint(@50) is consistent with current view of log(@50)
 I0311 18:45:28.505208  243805 main.go:126] ✅ Device verified OK!
-I0311 18:45:28.505212  243805 main.go:127] ----------------------------------------------------------------------------------------------
-I0311 18:45:28.505215  243805 main.go:128] 🙏 Operator, please ensure boot switch is set to MMC, and then reboot device 🙏
-I0311 18:45:28.505222  243805 main.go:129] ----------------------------------------------------------------------------------------------
+I0311 18:45:28.505212  243805 main.go:127] -------------------------------------------------------------------------------------------------------------
+I0311 18:45:28.505215  243805 main.go:128] 🔷🔷🔷  🙏 Operator, please ensure boot switch is set to MMC (away from RJ45 socket), and then reboot device 🙏
+I0311 18:45:28.505222  243805 main.go:129] -------------------------------------------------------------------------------------------------------------
 ```
 
 In the above run, we can see a successfully verified device which was provisioned onto the `ci` release train.

--- a/cmd/verify/main.go
+++ b/cmd/verify/main.go
@@ -126,9 +126,9 @@ func main() {
 		klog.Exitf("❌ Failed to verify device: %v", err)
 	}
 	klog.Info("✅ Device verified OK!")
-	klog.Info("----------------------------------------------------------------------------------------------")
-	klog.Infof(operPlease, "please ensure boot switch is set to MMC, and then reboot device")
-	klog.Info("----------------------------------------------------------------------------------------------")
+	klog.Info("------------------------------------------------------------------------------------------------------------")
+	klog.Infof(operPlease, "please ensure boot switch is set to MMC (away from RJ45 socket), and then reboot device")
+	klog.Info("------------------------------------------------------------------------------------------------------------")
 }
 
 // firmwares respresents the collection of firmware and related artefacts found
@@ -215,9 +215,9 @@ func (v *verifier) waitAndVerify(ctx context.Context) error {
 		klog.Exitf("Failed to fetch device recovery image: %v", err)
 	}
 	klog.Info("Successfully fetched and verified recovery image")
-	klog.Info("----------------------------------------------------------------------------------------------")
-	klog.Infof(operPlease, "please ensure boot switch is set to USB, and then connect device")
-	klog.Info("----------------------------------------------------------------------------------------------")
+	klog.Info("------------------------------------------------------------------------------------------------------------")
+	klog.Infof(operPlease, "please ensure boot switch is set to USB (towards RJ45 socket), and then connect device")
+	klog.Info("------------------------------------------------------------------------------------------------------------")
 
 	recoveryHAB := append(v.recovery.Firmware, v.recovery.HABSignature...)
 	klog.Infof("Recovery firmware is %d bytes + %d bytes HAB signature", len(v.recovery.Firmware), len(v.recovery.HABSignature))

--- a/docs/custodian.md
+++ b/docs/custodian.md
@@ -68,9 +68,9 @@ I0412 10:40:28.663963 2193170 main.go:98] Using template flag setting --os_verif
 I0412 10:40:28.663982 2193170 main.go:98] Using template flag setting --os_verifier_2=transparency.dev-aw-os2-prod+662add8c+AebLJIKJhx57T3mWmHKe0sasFnXmtIQNTGRaoj2PQLrY
 I0412 10:40:29.681000 2193170 fetcher.go:88] Fetching RECOVERY bin from "8271e2a8ccefb6c4df48889fcbb35343511501e3bcd527317d9e63e2ac7349e3"
 I0412 10:40:29.879505 2193170 main.go:217] Successfully fetched and verified recovery image
-I0412 10:40:29.879519 2193170 main.go:218] ----------------------------------------------------------------------------------------------
-I0412 10:40:29.879523 2193170 main.go:219] 🔷🔷🔷 🙋 OPERATOR: please ensure boot switch is set to USB, and then connect device 🙏
-I0412 10:40:29.879526 2193170 main.go:220] ----------------------------------------------------------------------------------------------
+I0412 10:40:29.879519 2193170 main.go:218] ------------------------------------------------------------------------------------------------------------
+I0412 10:40:29.879523 2193170 main.go:219] 🔷🔷🔷 🙋 OPERATOR: please ensure boot switch is set to USB (towards RJ45 socket), and then connect device 🙏
+I0412 10:40:29.879526 2193170 main.go:220] ------------------------------------------------------------------------------------------------------------
 I0412 10:40:29.879530 2193170 main.go:223] Recovery firmware is 1924096 bytes + 16384 bytes HAB signature
 I0412 10:40:29.879540 2193170 recovery.go:64] Waiting for device to be detected...
 I0412 10:46:13.033524 2193170 sdp.go:85] found device 15a2:007d Freescale SemiConductor Inc  SE Blank 6UL
@@ -97,9 +97,9 @@ I0412 10:46:21.715029 2193170 main.go:314]   ✅ TrustedOS: proof bundle checkpo
 I0412 10:46:21.735579 2193170 main.go:291]   ✅ TrustedApplet: proof bundle is self-consistent
 I0412 10:46:21.735666 2193170 main.go:314]   ✅ TrustedApplet: proof bundle checkpoint(@7) is consistent with current view of log(@7)
 I0412 10:46:21.735672 2193170 main.go:128] ✅ Device verified OK!
-I0412 10:46:21.735681 2193170 main.go:129] ----------------------------------------------------------------------------------------------
-I0412 10:46:21.735685 2193170 main.go:130] 🔷🔷🔷 🙋 OPERATOR: please ensure boot switch is set to MMC, and then reboot device 🙏
-I0412 10:46:21.735689 2193170 main.go:131] ---------------------------------------------------------------------------------------------- 
+I0412 10:46:21.735681 2193170 main.go:129] ------------------------------------------------------------------------------------------------------------
+I0412 10:46:21.735685 2193170 main.go:130] 🔷🔷🔷 🙋 OPERATOR: please ensure boot switch is set to MMC (away from RJ45 socket), and then reboot device 🙏
+I0412 10:46:21.735689 2193170 main.go:131] ------------------------------------------------------------------------------------------------------------
 ```
 
 The block of ✅ green ticks towards the end indicates that the firmware on the device was successfully verified.


### PR DESCRIPTION
It's not straightforward what the direction should be looking at the log messages. Eventually, I found this in `custodian.md`, "Verifying the device". Note that this makes log line exceed 100 characters.