### PR TITLE
Make dev distributor available via URL mappings

### DIFF
--- a/deployment/api_transparency_dev/terraform.tfvars
+++ b/deployment/api_transparency_dev/terraform.tfvars
@@ -14,3 +14,6 @@ distributor_prod_port = 443
 
 distributor_ci_host = "distributor-service-ci-oxxl2d5jeq-uc.a.run.app"
 distributor_ci_port = 443
+
+distributor_dev_host = "distributor-service-dev-oxxl2d5jeq-uc.a.run.app"
+distributor_dev_port = 443

--- a/deployment/api_transparency_dev/variables.tf
+++ b/deployment/api_transparency_dev/variables.tf
@@ -1,20 +1,20 @@
 variable "project_id" {
-  type = number
+  type        = number
   description = "The project ID to host the cluster in"
 }
 
 variable "project_name" {
-  type = string
+  type        = string
   description = "The string project ID"
 }
 
 variable "signing_keyring_location" {
-  type = string
+  type        = string
   description = "The GCP location to create the signing keyring"
 }
 
 variable "tf_state_location" {
-  type = string
+  type        = string
   description = "The GCP location to store Terraform remote state"
 }
 
@@ -29,7 +29,7 @@ variable "tls" {
 }
 
 variable "distributor_prod_host" {
-  type = string
+  type        = string
   description = "Host name serving distributor service API (prod)"
 }
 variable "distributor_prod_port" {
@@ -37,15 +37,23 @@ variable "distributor_prod_port" {
   type        = number
 }
 variable "distributor_ci_host" {
-  type = string
+  type        = string
   description = "Host name serving distributor service API (ci)"
 }
 variable "distributor_ci_port" {
   description = "Port on distributor_host where distributor service API is served (ci)"
   type        = number
 }
+variable "distributor_dev_host" {
+  type        = string
+  description = "Host name serving distributor service API (dev)"
+}
+variable "distributor_dev_port" {
+  description = "Port on distributor_host where distributor service API is served (dev)"
+  type        = number
+}
 
 variable "lb_name" {
-  type = string
+  type        = string
   description = "Name of the load balancer"
 }


### PR DESCRIPTION
This will be available at api.transparency.dev/dev which is consistent with api.transparency.dev/ci
