### PR TITLE
Bump to TamaGo 1.24.1

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ['1.23.1']
+        go: ['1.24.1']
         include:
         - language: go
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]

--- a/.github/workflows/go_test.yml
+++ b/.github/workflows/go_test.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.23.x]
+        go-version: [1.24.x]
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,8 +16,7 @@ jobs:
         with:
           go-version-file: go.mod
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
+        uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
         with:
-          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.61.0
+          version: v2.0.1
           args: --timeout 5m

--- a/cmd/provision/main.go
+++ b/cmd/provision/main.go
@@ -257,12 +257,12 @@ func fetchLatestArtefacts(ctx context.Context) (*firmwares, error) {
 	}
 
 	if err := updateFetcher.Scan(ctx); err != nil {
-		return nil, fmt.Errorf("Scan: %v", err)
+		return nil, fmt.Errorf("updateFetcher.Scan: %v", err)
 	}
 
 	fetchSession, err := updateFetcher.NewSession(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("NewSession: %v", err)
+		return nil, fmt.Errorf("updateFetcher.NewSession: %v", err)
 	}
 	bp := overridableBundleProvider{
 		delegate:     updateFetcher,
@@ -274,7 +274,7 @@ func fetchLatestArtefacts(ctx context.Context) (*firmwares, error) {
 
 	osFW, err := bp.GetOS(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("GetOS: %v", err)
+		return nil, fmt.Errorf("bp.GetOS: %v", err)
 	}
 	klog.Infof("Found OS bundle @ %d", osFW.Index)
 	firmwares.trustedOS = &fw{
@@ -284,7 +284,7 @@ func fetchLatestArtefacts(ctx context.Context) (*firmwares, error) {
 
 	appletFW, err := bp.GetApplet(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("GetApplet: %v", err)
+		return nil, fmt.Errorf("bp.GetApplet: %v", err)
 	}
 	klog.Infof("Found Applet bundle @ %d", appletFW.Index)
 	firmwares.trustedApplet = &fw{
@@ -294,7 +294,7 @@ func fetchLatestArtefacts(ctx context.Context) (*firmwares, error) {
 
 	bootFW, err := bp.GetBoot(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("GetBoot: %v", err)
+		return nil, fmt.Errorf("bp.GetBoot: %v", err)
 	}
 	klog.Infof("Found Bootloader bundle @ %d", bootFW.Index)
 	firmwares.bootloader = &fw{
@@ -305,7 +305,7 @@ func fetchLatestArtefacts(ctx context.Context) (*firmwares, error) {
 
 	recoveryFW, err := bp.GetRecovery(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("GetRecovery: %v", err)
+		return nil, fmt.Errorf("bp.GetRecovery: %v", err)
 	}
 	klog.Infof("Found Recovery bundle @ %d", recoveryFW.Index)
 	firmwares.recovery = &fw{
@@ -416,7 +416,7 @@ func waitAndProvision(ctx context.Context, fw *firmwares) error {
 	klog.Infof("✅ Witness serial number %s found", s.Serial)
 	if s.HAB {
 		if *fuse && !*runAnyway {
-			return fmt.Errorf("witness serial number %s has HAB fuse set!", s.Serial)
+			return fmt.Errorf("witness serial number %s has HAB fuse set", s.Serial)
 		}
 		klog.Infof("⚠️  Witness serial number %s is already HAB fused", s.Serial)
 	} else {
@@ -425,14 +425,14 @@ func waitAndProvision(ctx context.Context, fw *firmwares) error {
 
 	srkEnv, ok := expectedSRKHashes[s.SRKHash]
 	if !ok {
-		e := fmt.Errorf("witness OS reports UNKNOWN SRK Hash '%s', not fusing.", s.SRKHash)
+		e := fmt.Errorf("witness OS reports UNKNOWN SRK Hash '%s', not fusing", s.SRKHash)
 		if *fuse {
 			return e
 		}
 		klog.Warningf("⚠️  %s", e.Error())
 	}
 	if srkEnv != *habTarget {
-		e := fmt.Errorf("witness OS reports SRK Hash (%s) for unexpected release environment %q - we're set to %q, not fusing.", s.SRKHash, srkEnv, *habTarget)
+		e := fmt.Errorf("witness OS reports SRK Hash (%s) for unexpected release environment %q - we're set to %q, not fusing", s.SRKHash, srkEnv, *habTarget)
 		if *fuse {
 			return e
 		}
@@ -665,11 +665,11 @@ func (p *overridableBundleProvider) GetOS(ctx context.Context) (firmware.Bundle,
 		return firmware.Bundle{}, err
 	}
 	if release.Component != ftlog.ComponentOS {
-		return firmware.Bundle{}, fmt.Errorf("Overridden OS index %d is of type %s, not required type %s", i, release.Component, ftlog.ComponentOS)
+		return firmware.Bundle{}, fmt.Errorf("overridden OS index %d is of type %s, not required type %s", i, release.Component, ftlog.ComponentOS)
 	}
 	bundle.Firmware, _, err = p.binFetcher(ctx, *release)
 	if err != nil {
-		return firmware.Bundle{}, fmt.Errorf("BinaryFetcher(): %v", err)
+		return firmware.Bundle{}, fmt.Errorf("binFetcher(): %v", err)
 	}
 
 	return *bundle, nil
@@ -687,11 +687,11 @@ func (p *overridableBundleProvider) GetApplet(ctx context.Context) (firmware.Bun
 		return firmware.Bundle{}, err
 	}
 	if release.Component != ftlog.ComponentApplet {
-		return firmware.Bundle{}, fmt.Errorf("Overridden Applet index %d is of type %s, not required type %s", i, release.Component, ftlog.ComponentApplet)
+		return firmware.Bundle{}, fmt.Errorf("overridden Applet index %d is of type %s, not required type %s", i, release.Component, ftlog.ComponentApplet)
 	}
 	bundle.Firmware, _, err = p.binFetcher(ctx, *release)
 	if err != nil {
-		return firmware.Bundle{}, fmt.Errorf("BinaryFetcher(): %v", err)
+		return firmware.Bundle{}, fmt.Errorf("binFetcher(): %v", err)
 	}
 
 	return *bundle, nil

--- a/cmd/sign/main.go
+++ b/cmd/sign/main.go
@@ -29,6 +29,7 @@ import (
 	"os"
 
 	"github.com/transparency-dev/armored-witness/pkg/kmssigner"
+	"k8s.io/klog/v2"
 
 	kms "cloud.google.com/go/kms/apiv1"
 	"golang.org/x/exp/maps"
@@ -141,9 +142,9 @@ func main() {
 		"The file to write the note to.")
 
 	flag.Usage = func() {
-		fmt.Fprintf(flag.CommandLine.Output(), "Usage of %s:\n", os.Args[0])
-		fmt.Fprintf(flag.CommandLine.Output(), usageString+"\n\n")
-		fmt.Fprintf(flag.CommandLine.Output(), "Flags:\n")
+		_, _ = fmt.Fprintf(flag.CommandLine.Output(), "Usage of %s:\n", os.Args[0])
+		_, _ = fmt.Fprintf(flag.CommandLine.Output(), usageString+"\n\n")
+		_, _ = fmt.Fprintf(flag.CommandLine.Output(), "Flags:\n")
 		flag.PrintDefaults()
 	}
 
@@ -172,7 +173,11 @@ func main() {
 	if err != nil {
 		log.Fatalf("failed to create KeyManagementClient: %v", err)
 	}
-	defer kmClient.Close()
+	defer func() {
+		if err := kmClient.Close(); err != nil {
+			klog.Errorf("kmClient.Close: %v", err)
+		}
+	}()
 
 	verifier, err := note.NewVerifier(keyInfo.noteVerifier)
 	if err != nil {

--- a/cmd/verify/main.go
+++ b/cmd/verify/main.go
@@ -178,16 +178,16 @@ func (v *verifier) fetchRecoveryFirmware(ctx context.Context) error {
 			HABTarget:        *habTarget,
 		})
 	if err != nil {
-		return fmt.Errorf("NewFetcher: %v", err)
+		return fmt.Errorf("update.NewFetcher: %v", err)
 	}
 
 	if err := updateFetcher.Scan(ctx); err != nil {
-		return fmt.Errorf("Scan: %v", err)
+		return fmt.Errorf("updateFetcher.Scan: %v", err)
 	}
 
 	r, err := updateFetcher.GetRecovery(ctx)
 	if err != nil {
-		return fmt.Errorf("GetRecovery: %v", err)
+		return fmt.Errorf("updateFetcher.GetRecovery: %v", err)
 	}
 
 	bv := firmware.BundleVerifier{

--- a/cmd/verify_build/Dockerfile
+++ b/cmd/verify_build/Dockerfile
@@ -3,7 +3,7 @@
 # witness.
 # The default entrypoint runs a continuous monitor that attempts
 # to build all firmware artifacts committed to by a log.
-FROM golang:1.23-alpine AS builder
+FROM golang:1.24-alpine AS builder
 
 ARG GOFLAGS=""
 ENV GOFLAGS=$GOFLAGS

--- a/cmd/verify_build/cmd/continuous.go
+++ b/cmd/verify_build/cmd/continuous.go
@@ -223,7 +223,11 @@ func newFetcher(root *url.URL) (client.Fetcher, error) {
 		if err != nil {
 			return nil, err
 		}
-		defer resp.Body.Close()
+		defer func() {
+			if err := resp.Body.Close(); err != nil {
+				klog.Errorf("Close: %v", err)
+			}
+		}()
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, err

--- a/cmd/verify_build/cmd/internal/build/metadata.go
+++ b/cmd/verify_build/cmd/internal/build/metadata.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 
 	"golang.org/x/mod/sumdb/note"
+	"k8s.io/klog/v2"
 )
 
 func NewReleaseImplicitMetadata(logV, osV1, osV2, appV, bootV, recoveryV string) (*ReleaseImplicitMetadata, error) {
@@ -80,7 +81,9 @@ func NewReleaseImplicitMetadata(logV, osV1, osV2, appV, bootV, recoveryV string)
 			fmt.Sprintf("OS_PUBLIC_KEY2=%s", os2File),
 		},
 		Cleanup: func() {
-			os.RemoveAll(dir)
+			if err := os.RemoveAll(dir); err != nil {
+				klog.Errorf("RemoveAll: %v", err)
+			}
 		},
 	}, nil
 }

--- a/cmd/verify_build/cmd/internal/build/verify.go
+++ b/cmd/verify_build/cmd/internal/build/verify.go
@@ -94,7 +94,7 @@ func (v *ReproducibleBuildVerifier) Verify(ctx context.Context, i uint64, manife
 			return false, fmt.Errorf("recovery sig verification failed: %v", err)
 		}
 	default:
-		return false, fmt.Errorf("Unsupported component: %q", release.Component)
+		return false, fmt.Errorf("unsupported component: %q", release.Component)
 	}
 
 	klog.V(1).Infof("Leaf index %d: verifying manifest: %s@%s (%s)", i, release.Component, release.Git.TagName, release.Git.CommitFingerprint)
@@ -118,7 +118,7 @@ func (v *ReproducibleBuildVerifier) verifyManifest(ctx context.Context, i uint64
 	case ftlog.ComponentRecovery:
 		cv = recoveryVerifier{}
 	default:
-		return false, fmt.Errorf("Unsupported component: %q", r.Component)
+		return false, fmt.Errorf("unsupported component: %q", r.Component)
 	}
 
 	// Download, install, and then set up tamago environment to match manifest
@@ -139,7 +139,9 @@ func (v *ReproducibleBuildVerifier) verifyManifest(ctx context.Context, i uint64
 	cleanup := v.cleanup
 	defer func() {
 		if cleanup {
-			os.RemoveAll(dir)
+			if err := os.RemoveAll(dir); err != nil {
+				klog.Errorf("RemoveAll: %v", err)
+			}
 		} else {
 			klog.Infof("🔎 Evidence of failed build: %s (%d: %s@%s)", dir, i, r.Component, r.Git.CommitFingerprint)
 		}

--- a/deployment/build_and_release/live/ci/terragrunt.hcl
+++ b/deployment/build_and_release/live/ci/terragrunt.hcl
@@ -19,7 +19,7 @@ inputs = merge(
     firmware_bucket_prefix = "armored-witness-firmware-ci"
     origin_prefix = "transparency.dev/armored-witness/firmware_transparency/ci"
 
-    tamago_version = "1.23.1"
+    tamago_version = "1.24.1"
     log_public_key = "transparency.dev-aw-ftlog-ci-4+30fe79e3+AUDoas+smwQDTlYbTzbEcAW+N6WyvB/4CysMWjpnRgat"
     applet_public_key = "transparency.dev-aw-applet-ci+3ff32e2c+AV1fgxtByjXuPjPfi0/7qTbEBlPGGCyxqr6ZlppoLOz3"
     os_public_key1 = "transparency.dev-aw-os1-ci+7a0eaef3+AcsqvmrcKIbs21H2Bm2fWb6oFWn/9MmLGNc6NLJty2eQ"

--- a/deployment/build_and_release/live/presubmit/terragrunt.hcl
+++ b/deployment/build_and_release/live/presubmit/terragrunt.hcl
@@ -13,7 +13,7 @@ inputs = merge(
     log_shard = 2
     origin_prefix = "transparency.dev/armored-witness/firmware_transparency/ci"
 
-    tamago_version = "1.23.1"
+    tamago_version = "1.24.1"
     log_public_key = "transparency.dev-aw-ftlog-ci-2+f77c6276+AZXqiaARpwF4MoNOxx46kuiIRjrML0PDTm+c7BLaAMt6"
     applet_public_key = "transparency.dev-aw-applet-ci+3ff32e2c+AV1fgxtByjXuPjPfi0/7qTbEBlPGGCyxqr6ZlppoLOz3"
     os_public_key1 = "transparency.dev-aw-os1-ci+7a0eaef3+AcsqvmrcKIbs21H2Bm2fWb6oFWn/9MmLGNc6NLJty2eQ"

--- a/deployment/build_and_release/live/prod/terragrunt.hcl
+++ b/deployment/build_and_release/live/prod/terragrunt.hcl
@@ -21,7 +21,7 @@ inputs = merge(
     firmware_bucket_prefix = "armored-witness-firmware-prod"
     origin_prefix = "transparency.dev/armored-witness/firmware_transparency/prod"
     
-    tamago_version = "1.23.1"
+    tamago_version = "1.24.1"
     log_public_key = "transparency.dev-aw-ftlog-prod-1+3e6d87ee+Aa3qdhefd2cc/98jV3blslJT2L+iFR8WKHeGcgFmyjnt"
     applet_public_key = "transparency.dev-aw-applet-prod+d45f2a0d+AZSnFa8GxH+jHV6ahELk6peqVObbPKrYAdYyMjrzNF35"
     os_public_key1 = "transparency.dev-aw-os1-prod+985bdfd2+AV7mmRamQp6VC9CutzSXzqtNhYNyNmQQRcLX07F6qlC1"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/transparency-dev/armored-witness
 
-go 1.23.1
+go 1.24.1
 
 require (
 	cloud.google.com/go/kms v1.21.1

--- a/internal/device/recovery.go
+++ b/internal/device/recovery.go
@@ -138,7 +138,11 @@ func probeDevice(ctx context.Context, p string) error {
 			if err != nil {
 				return err
 			}
-			defer f.Close()
+			defer func() {
+				if err := f.Close(); err != nil {
+					klog.Errorf("Close: %v", err)
+				}
+			}()
 			b := make([]byte, 1024)
 			if _, err := f.Read(b); err != nil {
 				return err


### PR DESCRIPTION
This PR is bumps TamaGo to `1.24.1`.

Related:
 - transparency-dev/armored-witness-os#316
 - transparency-dev/armored-witness-applet#391
 - transparency-dev/armored-witness-boot#163
 
Applied:
 - [X] `deployment/build_and_release/live/presubmit` 
 - [x] `deployment/build_and_release/live/ci` 
 - [x] `deployment/build_and_release/live/prod` 