### PR TITLE
Bump to Tamago-go 1.24.3

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ['1.24.1']
+        go: ['1.24.3']
         include:
         - language: go
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]

--- a/deployment/build_and_release/live/ci/terragrunt.hcl
+++ b/deployment/build_and_release/live/ci/terragrunt.hcl
@@ -19,7 +19,7 @@ inputs = merge(
     firmware_bucket_prefix = "armored-witness-firmware-ci"
     origin_prefix = "transparency.dev/armored-witness/firmware_transparency/ci"
 
-    tamago_version = "1.24.1"
+    tamago_version = "1.24.3"
     log_public_key = "transparency.dev-aw-ftlog-ci-4+30fe79e3+AUDoas+smwQDTlYbTzbEcAW+N6WyvB/4CysMWjpnRgat"
     applet_public_key = "transparency.dev-aw-applet-ci+3ff32e2c+AV1fgxtByjXuPjPfi0/7qTbEBlPGGCyxqr6ZlppoLOz3"
     os_public_key1 = "transparency.dev-aw-os1-ci+7a0eaef3+AcsqvmrcKIbs21H2Bm2fWb6oFWn/9MmLGNc6NLJty2eQ"

--- a/deployment/build_and_release/live/presubmit/terragrunt.hcl
+++ b/deployment/build_and_release/live/presubmit/terragrunt.hcl
@@ -13,7 +13,7 @@ inputs = merge(
     log_shard = 2
     origin_prefix = "transparency.dev/armored-witness/firmware_transparency/ci"
 
-    tamago_version = "1.24.1"
+    tamago_version = "1.24.3"
     log_public_key = "transparency.dev-aw-ftlog-ci-2+f77c6276+AZXqiaARpwF4MoNOxx46kuiIRjrML0PDTm+c7BLaAMt6"
     applet_public_key = "transparency.dev-aw-applet-ci+3ff32e2c+AV1fgxtByjXuPjPfi0/7qTbEBlPGGCyxqr6ZlppoLOz3"
     os_public_key1 = "transparency.dev-aw-os1-ci+7a0eaef3+AcsqvmrcKIbs21H2Bm2fWb6oFWn/9MmLGNc6NLJty2eQ"

--- a/deployment/build_and_release/live/prod/terragrunt.hcl
+++ b/deployment/build_and_release/live/prod/terragrunt.hcl
@@ -21,7 +21,7 @@ inputs = merge(
     firmware_bucket_prefix = "armored-witness-firmware-prod"
     origin_prefix = "transparency.dev/armored-witness/firmware_transparency/prod"
     
-    tamago_version = "1.24.1"
+    tamago_version = "1.24.3"
     log_public_key = "transparency.dev-aw-ftlog-prod-1+3e6d87ee+Aa3qdhefd2cc/98jV3blslJT2L+iFR8WKHeGcgFmyjnt"
     applet_public_key = "transparency.dev-aw-applet-prod+d45f2a0d+AZSnFa8GxH+jHV6ahELk6peqVObbPKrYAdYyMjrzNF35"
     os_public_key1 = "transparency.dev-aw-os1-prod+985bdfd2+AV7mmRamQp6VC9CutzSXzqtNhYNyNmQQRcLX07F6qlC1"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/transparency-dev/armored-witness
 
-go 1.24.1
+go 1.24.3
 
 require (
 	cloud.google.com/go/kms v1.22.0


### PR DESCRIPTION
This PR bumps the build pipeline and local Go versions to `[tamago-]go1.24.3`.