### PR TITLE
Bump golangci-lint from 2.2.1 to 2.5.0

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,5 +18,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
-          version: v2.2.1
+          version: v2.5.0
           args: --timeout 5m


### PR DESCRIPTION
Unblock https://github.com/transparency-dev/armored-witness/pull/382.